### PR TITLE
docs(data-simulator): full service documentation set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,67 @@
-# Smart City Trash Bin Monitor - BinForge 🏙️
+# Smart City Trash Bin Monitor — BinForge 🏙️
 
-Data Simulator is the data generation service for the Smart City Trash Bin Monitor. It simulates thousands of IoT trash bins concurrently and publishes real-time telemetry (fill levels, locations, timestamps) to Apache Kafka.
+**Data Simulator** is the data-generation service for the Smart City Trash Bin
+Monitor. It simulates a fleet of IoT trash bins concurrently (one asyncio task
+per bin) and publishes real-time telemetry — fill level, battery level,
+location, timestamp — to Apache Kafka. Static bin metadata lives in PostgreSQL;
+the dynamic telemetry state is generated in memory and streamed out.
 
-## Architecture
+## Stack
 
 - **Simulator**: Python 3.12 (AsyncIO)
-- **Database**: PostgreSQL 15
-- **Message Broker**: Apache Kafka (KRaft mode)
+- **Database**: PostgreSQL 15 (bin metadata only)
+- **Message Broker**: Apache Kafka (KRaft mode, no ZooKeeper)
+
+📚 **Full documentation:** [`docs/features/data-simulator/`](docs/features/data-simulator/)
+— start with [architecture.md](docs/features/data-simulator/architecture.md).
+
+---
 
 ## Quick Start (Docker)
 
-### 1. Environment Configuration
+Run all commands from the repository root.
 
-The repository includes a template file. You must copy it to create your private `.env.docker.local` file inside the `services/data-simulator` directory:
+### 1. Environment configuration
+
+Docker Compose reads `services/data-simulator/.env.docker`. That file is
+git-ignored, so create it from the template on a fresh clone:
 
 ```bash
-cp services/data-simulator/.env.local.example services/data-simulator/.env.docker.local
+cp services/data-simulator/.env.local.example services/data-simulator/.env.docker
 ```
 
-_(Note: If you plan to run the Python script natively instead of via Docker, create a `.env.local` file instead)._
+Set the Docker-network values inside it: `POSTGRES_HOST=postgres` and
+`KAFKA_BOOTSTRAP_SERVERS=kafka:29092`.
 
-### 2. Start Infrastructure
+> ⚠️ Compose reads **`.env.docker`** — not `.env.docker.local`. See
+> [configuration.md](docs/features/data-simulator/configuration.md) for details.
+> _(If you instead run the simulator natively, create `.env.local` with
+> `localhost` values — see [deployment.md](docs/features/data-simulator/deployment.md).)_
 
-Build and start the unified Docker stack:
+### 2. Start the stack
 
 ```bash
 docker compose up -d --build
 ```
 
-_(The simulator will not emit telemetry until the database is migrated and seeded.)_
+_(The simulator emits no telemetry until the schema exists and ACTIVE bins are
+seeded.)_
 
-### 3. Database Migration & Seeding
+### 3. Create the schema and seed data
 
-Initialize the schema and seed mock data using a one-off container:
+The schema is created from ORM metadata (there are no Alembic migrations), then
+seeded with mock bins — both via one-off containers:
 
 ```bash
+docker compose run --rm data_simulator python src/create_tables.py
 docker compose run --rm data_simulator python src/seed.py --count 50
 ```
 
-_(To reset the database later, append `--clear` to the seed command)._
+_(To reset later, add `--clear` to the seed command; max 500 bins per run.)_
 
-### 4. Restart Simulator
+### 4. Restart the simulator
 
-Restart the simulator to pick up the seeded data:
+Bins are loaded once at startup, so restart to pick up the seeded data:
 
 ```bash
 docker compose restart data_simulator
@@ -52,55 +71,71 @@ docker compose restart data_simulator
 
 ## Verification & Debugging
 
-**View Simulator Logs:**
+**Simulator logs:**
 
 ```bash
 docker logs data_simulator -f
 ```
 
-**Verify Postgres Data:**
+**Postgres data:**
 
 ```bash
-docker exec -it smartbin_postgres psql -U postgres -d smart_city -c "SELECT bin_id, capacity, latitude, longitude, status FROM smart_bins LIMIT 10;"
+docker exec -it smartbin_postgres psql -U postgres -d smart_city \
+  -c "SELECT bin_id, capacity, latitude, longitude, status FROM smart_bins LIMIT 10;"
 ```
 
-**Consume Live Kafka Stream:**
+**Live Kafka stream:**
 
 ```bash
-docker exec -it smartbin_kafka kafka-console-consumer --bootstrap-server localhost:9092 --topic smartbin-telemetry-v1
+docker exec -it smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-v1
 ```
+
+More: [operations.md](docs/features/data-simulator/operations.md) ·
+[troubleshooting.md](docs/features/data-simulator/troubleshooting.md).
+
+---
 
 ## Testing
 
-The data simulator comes with a comprehensive `pytest` suite that tests all the core simulation logic, database schema, and Kafka integrations.
-
-To run the tests locally inside the running Docker container:
+A `pytest` suite covers the simulation logic, database model, and Kafka client
+(all mocked — no live infra needed). Run it inside the running container without
+rebuilding:
 
 ```bash
 docker exec -it data_simulator pip install -r requirements-dev.txt
 docker exec -it data_simulator pytest -v
 ```
 
-_(This allows you to test instantly without having to rebuild the Docker image.)_
+Or locally from `services/data-simulator/`: `PYTHONPATH=src pytest -v`. See
+[testing.md](docs/features/data-simulator/testing.md).
 
-## CI/CD Pipeline
+---
 
-We enforce a strict CI/CD pipeline using GitHub Actions to ensure code quality and prevent regressions.
+## CI/CD
 
-**Feature Policy:**
-When creating a feature branch, you must name it `feature/<service>/<task>` (e.g. `feature/data-simulator/add-tests`).
-The pipeline enforces that a feature branch only modifies files within its own service directory (e.g., `services/data-simulator/`).
+GitHub Actions runs on pull requests to **`develop`**
+(see [ci-cd.md](docs/features/data-simulator/ci-cd.md)):
 
-**Local Testing with `act`:**
-You can test the GitHub Actions CI pipeline locally before pushing your code using `act`:
+- **Feature policy** — branches must be named `feature/<service>/<task>` and may
+  modify only their own service (or, for a `docs` task, only
+  `docs/features/<service>/**`).
+- **PR Pytest** — installs deps and runs `pytest -v` on Python 3.12.
+
+_CI runs tests and policy checks only — it does not lint, build, or deploy._
+Ruff/mypy/pre-commit are configured for **local** use, not enforced in CI.
+
+**Run the pipeline locally with [`act`](https://github.com/nektos/act):**
 
 ```bash
 act pull_request -e event.json -W .github/workflows/pr-controller.yml
 ```
 
-This spins up a local GitHub runner, validates the feature policy, runs the Ruff linter, and executes the Pytest suite inside the CI Docker environment.
+---
 
 ## Operations
 
-- **Stop Stack**: `docker compose down`
-- **Hard Reset (Wipe all data)**: `docker compose down -v`
+- **Stop stack**: `docker compose down`
+- **Hard reset (wipe all data)**: `docker compose down -v`
+
+Runbook: [operations.md](docs/features/data-simulator/operations.md).

--- a/docs/features/data-simulator/architecture.md
+++ b/docs/features/data-simulator/architecture.md
@@ -1,0 +1,149 @@
+# Architecture
+
+The Data Simulator is a single Python 3.12 asyncio process that simulates a
+fleet of IoT smart trash bins and publishes their telemetry to Kafka. It reads
+static bin metadata from PostgreSQL, then generates dynamic telemetry (fill
+level, battery level, location, timestamp) entirely in memory.
+
+This document covers the runtime structure and component interactions. For
+env-var details see [configuration.md](configuration.md); for the simulation
+math see [simulation-engine.md](simulation-engine.md).
+
+---
+
+## System diagram
+
+```mermaid
+flowchart TB
+    subgraph Simulator["data_simulator process (asyncio)"]
+        main["main.py<br/>entrypoint + shutdown"]
+        mgr["SimulationManager<br/>dict[bin_id → BinSimulator]"]
+        sim1["BinSimulator (bin A)<br/>asyncio.Task"]
+        sim2["BinSimulator (bin B)<br/>asyncio.Task"]
+        simN["BinSimulator (bin N)<br/>asyncio.Task"]
+        kc["kafka_client<br/>(AIOKafkaProducer)"]
+
+        main --> mgr
+        mgr --> sim1
+        mgr --> sim2
+        mgr --> simN
+        sim1 --> kc
+        sim2 --> kc
+        simN --> kc
+    end
+
+    pg[("PostgreSQL<br/>smart_bins table")]
+    kafka[["Kafka topic<br/>smartbin-telemetry-v1"]]
+
+    mgr -- "load ACTIVE bins (once, at startup)" --> pg
+    kc -- "produce JSON, key=bin_id" --> kafka
+```
+
+Verified sources: `src/main.py`, `src/simulator/simulation_manager.py`,
+`src/simulator/bin_simulator.py`, `src/kafka_producer.py`, `src/database.py`,
+`docker-compose.yml`.
+
+---
+
+## Major components
+
+| Component | File | Role |
+| --- | --- | --- |
+| Entrypoint | `src/main.py` | Boots the Kafka client and `SimulationManager`, wires signal handlers, and performs bounded graceful shutdown. |
+| Simulation Manager | `src/simulator/simulation_manager.py` | In-memory registry mapping `bin_id → BinSimulator`. Loads ACTIVE bins from the DB and starts a simulator per bin. |
+| Bin Simulator | `src/simulator/bin_simulator.py` | Owns one `Bin` and runs a long-lived asyncio task that updates state and publishes telemetry on an interval. |
+| Bin (domain model) | `src/models/bin.py` | Pure in-memory object holding a bin's live state and producing the telemetry payload. Infrastructure-agnostic. |
+| Kafka client | `src/kafka_producer.py` | Module-level singleton `kafka_client` wrapping `AIOKafkaProducer`, with start-up retries and per-message error handling. |
+| Database layer | `src/database.py` | Async SQLAlchemy engine + `AsyncSessionLocal` factory + the `SmartBin` ORM model (static bin metadata). |
+| Config | `src/config.py` | Pydantic `Settings`, cached via `get_settings()`. |
+| Logging | `src/logging_config.py` | Root logging setup + runtime DEBUG toggle via SIGUSR1. |
+
+---
+
+## Runtime flow
+
+Startup (from `src/main.py`):
+
+1. `setup_logging()` runs once at import time (module top of `main.py`).
+2. `await kafka_client.start()` — connects the producer, retrying up to 10 times
+   (3s apart) before raising (`src/kafka_producer.py:16-44`).
+3. `SimulationManager()` is constructed, then `await manager.initialize()`
+   opens one DB session, selects `SmartBin` rows `where status == "ACTIVE"`, and
+   for each row builds a `Bin`, wraps it in a `BinSimulator`, calls
+   `simulator.start()`, and registers it
+   (`src/simulator/simulation_manager.py:34-65`).
+4. SIGINT/SIGTERM handlers are installed (via `loop.add_signal_handler`, or
+   `signal.signal` on Windows) that set an `asyncio.Event`
+   (`src/main.py:35-48`).
+5. `await stop_event.wait()` — the process now idles while the per-bin tasks run.
+
+Steady state: each `BinSimulator._run()` loops — mutate bin state
+(`_simulate()`), build a payload (`Bin.to_payload()`), `await
+kafka_client.send_telemetry(...)`, then `await asyncio.sleep(SIMULATION_INTERVAL)`
+(`src/simulator/bin_simulator.py:118-147`).
+
+Shutdown (on signal): `manager.stop()` cancels every simulator task and clears
+the registry, then `kafka_client.stop()` flushes/closes the producer, then
+`engine.dispose()` closes DB connections. Each teardown is wrapped in
+`asyncio.wait_for(..., timeout=5.0)` and its own try/except so one slow
+component cannot block the others (`src/main.py:52-68`).
+
+---
+
+## Concurrency: what is async vs. sync
+
+- **Async (`asyncio`):** the Kafka producer (`aiokafka`), all DB access
+  (SQLAlchemy async engine + `asyncpg`), the per-bin `_run()` loops, and
+  `main()` itself. Concurrency is cooperative on a single event loop — there are
+  no threads or subprocesses. See [decisions/001-asyncio.md](decisions/001-asyncio.md).
+- **Sync (CPU-only, no I/O):** the telemetry math in
+  `BinSimulator._simulate()` and `Bin.to_payload()`; these run to completion
+  between `await` points and never block on I/O.
+
+`SimulationManager`'s registry mutation helpers (`add_bin`, `update_bin`,
+`get_simulator`, `exists`) are plain synchronous methods; `remove_bin` and
+`stop` are async because they await simulator shutdown.
+
+---
+
+## State: what is stateful vs. stateless
+
+- **PostgreSQL (durable, static):** only bin *metadata* — `bin_id`, `capacity`,
+  `latitude`, `longitude`, `status`, `created_at`, `updated_at`
+  (`src/database.py:13-34`). The simulator reads this once at startup and does
+  **not** write telemetry back.
+- **In-memory (ephemeral, dynamic):** the live `current_fill_level` and
+  `battery_level` on each `Bin` (`src/models/bin.py:60-61`), plus the
+  `SimulationManager._simulators` registry. All of this is lost on restart and
+  rebuilt from the DB.
+- **Kafka (durable stream):** the emitted telemetry payloads — the only durable
+  record of the dynamic simulation output.
+
+> The `Bin` docstring states the design intent explicitly: "Only static bin
+> metadata is persisted. Dynamic simulation state (fill level, battery level,
+> etc.) is maintained in memory by the simulator"
+> (`src/database.py:14-20`, mirrored in `src/models/bin.py:6-18`).
+
+---
+
+## Deployment shape
+
+All three components run as containers defined in `docker-compose.yml`:
+`smartbin_postgres` (postgres:15-alpine), `smartbin_kafka`
+(confluentinc/cp-kafka:7.4.1, KRaft mode — no ZooKeeper), and `data_simulator`
+(built from the service `Dockerfile`). `data_simulator` `depends_on` postgres
+with `condition: service_healthy`. See [deployment.md](deployment.md) and
+[kafka.md](kafka.md).
+
+---
+
+## Known architectural gaps (verified in code)
+
+- The `SimulationManager` load is **one-shot at startup**. There is no
+  mechanism to pick up bins added to the DB after boot. The `add_bin` /
+  `update_bin` / `remove_bin` methods exist but are not wired to any trigger —
+  the code comment flags this: "Add, update, delete - need to be implemented
+  with Fast API in future involving DB interaction"
+  (`src/simulator/simulation_manager.py:67`).
+- `NUMBER_OF_BINS` (config) does **not** cap or drive the number of simulators;
+  the count is whatever the DB returns. See [configuration.md](configuration.md).

--- a/docs/features/data-simulator/ci-cd.md
+++ b/docs/features/data-simulator/ci-cd.md
@@ -1,0 +1,137 @@
+# CI/CD
+
+CI is GitHub Actions. There are **three** workflow files, all under
+`.github/workflows/`. CI runs **tests and governance checks only** — it does not
+build images, publish artifacts, or deploy. This document describes the
+pipeline exactly as the YAML defines it.
+
+| File | Name | Trigger |
+| --- | --- | --- |
+| `pr-controller.yml` | PR Governance Controller | `pull_request` → `develop` |
+| `feature-policy.yml` | Feature Branch Policy | `workflow_call` (reusable; invoked by the controller) |
+| `pr-pytest.yml` | PR Pytest | `pull_request` → `develop` |
+
+There are also two human-readable companion docs:
+`feature-policy-doc.md` and `pr-pytest-doc.md`.
+
+> **Trigger scope:** every workflow triggers on pull requests targeting
+> **`develop`**. PRs to other branches (e.g. `master`) do not run these checks.
+> *(TODO: confirm with team whether `master`/`main` should also be protected.)*
+
+---
+
+## 1. PR Governance Controller (`pr-controller.yml`)
+
+Routes a PR to the right policy based on its **branch name** (`github.head_ref`).
+
+`detect-branch` job parses the branch prefix (`pr-controller.yml:16-52`):
+
+| Branch prefix | `type` | Extracted |
+| --- | --- | --- |
+| `devops/…` | `devops` | `task` |
+| `platform/…` | `platform` | `task` |
+| `feature/<service>/<task>` | `feature` | `service`, `task` |
+| `bugfix/…` | `bugfix` | — |
+| anything else | — | **fails** ("Unknown branch type", `exit 1`) |
+
+Only the `feature` route is currently active — it calls the reusable
+`feature-policy.yml` with `service` and `task` (`pr-controller.yml:69-75`). The
+`devops`, `platform`, and `bugfix` routes are **commented out** in the YAML.
+
+---
+
+## 2. Feature Branch Policy (`feature-policy.yml`)
+
+Reusable workflow (`on: workflow_call`) taking `service` and `task` inputs. It
+enforces that a feature branch touches **only** files in its own scope, using
+`tj-actions/changed-files@v44` to list changed files
+(`feature-policy.yml:24-98`).
+
+| Case | Allowed paths | Rule |
+| --- | --- | --- |
+| `task == "docs"` | `docs/features/<service>/**` | Docs-only branches may modify only that service's docs. |
+| any other task | `services/<service>/**` | Standard feature branches may modify only their service directory. |
+
+Any changed file outside the allowed prefix prints
+`❌ Invalid change detected: <file>` and exits non-zero, failing the PR
+(`feature-policy.yml:70-95`). On success: `✅ Feature policy passed`.
+
+Concrete example (this very docs branch): a branch named
+`feature/data-simulator/docs` may modify only
+`docs/features/data-simulator/**`. See the companion `feature-policy-doc.md`
+for worked allowed/rejected examples.
+
+---
+
+## 3. PR Pytest (`pr-pytest.yml`)
+
+Runs the test suite. All steps run with
+`working-directory: services/data-simulator` (`pr-pytest.yml:16-18`).
+
+Steps (`pr-pytest.yml:20-45`):
+
+1. `actions/checkout@v4`.
+2. `actions/setup-python@v5` with Python **3.12**, `cache: pip`, keyed on
+   `requirements.txt` + `requirements-dev.txt`.
+3. `python -m pip install --upgrade pip`.
+4. `pip install -r requirements.txt`.
+5. `pip install -r requirements-dev.txt`.
+6. `pytest -v` with env `PYTHONPATH: src`.
+
+`permissions: contents: read` (`pr-pytest.yml:8-9`) — least-privilege token.
+
+---
+
+## What CI does NOT do (verified)
+
+- **No linting or type-checking in CI.** No workflow runs `ruff`, `black`, or
+  `mypy` (`grep -rn 'ruff\|black\|mypy' .github/workflows/` returns nothing) —
+  even though `ruff`, `mypy`, and `pre-commit` are in `requirements-dev.txt` and
+  a `ruff.toml` exists at the repo root. These are **local-only** quality gates.
+  The `pr-pytest-doc.md` lists Ruff/Black/MyPy/coverage as *future* enhancements.
+
+  > **Discrepancy:** the root `README.md` claims running `act` "validates the
+  > feature policy, runs the Ruff linter, and executes the Pytest suite." The
+  > actual workflows invoked on a PR run feature-policy + pytest **only** — no
+  > Ruff step exists. Treat the README's Ruff claim as inaccurate.
+  > *(TODO: confirm with team whether a Ruff CI step is intended.)*
+
+- **No coverage gate.** `pytest-cov` is installed and a `.coverage` file exists
+  locally, but the CI command is plain `pytest -v` — no `--cov` flag, no
+  threshold.
+- **No build/publish/deploy.** No `docker build`/`push`, no registry, no
+  environment deploy. The Dockerfile's `test` stage does run `pytest` at image
+  build time, but nothing in CI builds that image.
+
+---
+
+## Deploy gates
+
+There is no deployment stage, so there are no deploy gates in the pipeline. The
+effective merge gates (as intended) are the two required checks on `develop`:
+**Feature Branch Policy** and **PR Pytest**. `pr-pytest-doc.md` recommends
+configuring these as required status checks via branch protection; whether
+branch protection is actually enabled on GitHub is a repo setting, not visible
+in the code. *(TODO: confirm branch-protection settings with team.)*
+
+---
+
+## Running CI locally with `act`
+
+From the root README, using the sample event `event.json` (which sets
+`head.ref = feature/data-simulator/adding-pytests-for-simulation-flow`):
+
+```bash
+act pull_request -e event.json -W .github/workflows/pr-controller.yml
+```
+
+This runs the governance controller locally. (Per the discrepancy above, this
+does not run Ruff.)
+
+---
+
+## Related documents
+
+- [testing.md](testing.md) — the pytest suite CI executes.
+- [contributing.md](contributing.md) — branch naming that the policy enforces.
+- [deployment.md](deployment.md) — why there is no CD stage.

--- a/docs/features/data-simulator/configuration.md
+++ b/docs/features/data-simulator/configuration.md
@@ -1,0 +1,139 @@
+# Configuration
+
+All runtime configuration is supplied through environment variables and loaded
+by a single pydantic `Settings` model in `src/config.py`. This document lists
+every real config key, its purpose, default, and where it is read in code.
+
+---
+
+## How config is loaded
+
+`src/config.py` defines:
+
+```python
+class Settings(BaseSettings):
+    POSTGRES_HOST: str
+    POSTGRES_PORT: int
+    POSTGRES_DB: str
+    POSTGRES_USER: str
+    POSTGRES_PASSWORD: str
+
+    KAFKA_BOOTSTRAP_SERVERS: str
+    KAFKA_TOPIC: str
+
+    NUMBER_OF_BINS: int = 100
+    SIMULATION_INTERVAL: int = 5
+```
+
+- `Settings` extends `pydantic_settings.BaseSettings`, so each field is read
+  from the environment by matching name (case-sensitive to the names above).
+- Fields without a default (`POSTGRES_*`, `KAFKA_*`) are **required** — a
+  missing one raises `pydantic.ValidationError` at construction
+  (`tests/test_config.py:46-56`).
+- Settings are accessed through `get_settings()`, which is wrapped in
+  `functools.lru_cache`, so the environment is read once per process and the
+  same `Settings` instance is reused (`src/config.py:33-35`).
+- There is **no `.env` auto-loading configured in `config.py`** (no
+  `model_config`/`env_file`). Env vars must already be present in the process
+  environment. Docker Compose injects them via `env_file`; the local scripts
+  `source` an env file before launching (see [deployment.md](deployment.md)).
+
+---
+
+## Config keys
+
+| Key | Type | Required | Default | Purpose | Read in |
+| --- | --- | --- | --- | --- | --- |
+| `POSTGRES_HOST` | str | ✅ | — | DB host | `config.py` → `DATABASE_URL` |
+| `POSTGRES_PORT` | int | ✅ | — | DB port | `config.py` → `DATABASE_URL` |
+| `POSTGRES_DB` | str | ✅ | — | DB name | `config.py` → `DATABASE_URL` |
+| `POSTGRES_USER` | str | ✅ | — | DB user | `config.py` → `DATABASE_URL` |
+| `POSTGRES_PASSWORD` | str | ✅ | — | DB password | `config.py` → `DATABASE_URL` |
+| `KAFKA_BOOTSTRAP_SERVERS` | str | ✅ | — | Kafka bootstrap address(es) | `kafka_producer.py:24, 29, 43` |
+| `KAFKA_TOPIC` | str | ✅ | — | Telemetry topic name | `kafka_producer.py:59` |
+| `NUMBER_OF_BINS` | int | ❌ | `100` | *Declared but currently unused at runtime* — see note below | only referenced in `tests/test_config.py` |
+| `SIMULATION_INTERVAL` | int | ❌ | `5` | Seconds each `BinSimulator` sleeps between telemetry emissions | `bin_simulator.py:141` |
+
+### Derived value: `DATABASE_URL`
+
+`DATABASE_URL` is a pydantic `@computed_field`, not an env var. It is assembled
+from the five `POSTGRES_*` values (`src/config.py:19-27`):
+
+```text
+postgresql+asyncpg://{USER}:{PASSWORD}@{HOST}:{PORT}/{DB}
+```
+
+The `postgresql+asyncpg://` scheme selects the async `asyncpg` driver. It is
+consumed by `create_async_engine(...)` in `src/database.py:38` and
+`src/seed.py:21`. Behavior is pinned by `tests/test_config.py:20-27`.
+
+> **`NUMBER_OF_BINS` is dead config.** It is defined and tested, but no runtime
+> module reads it (`grep -rn NUMBER_OF_BINS src/` returns only `config.py`). The
+> number of simulated bins is determined by how many `ACTIVE` rows exist in the
+> `smart_bins` table (`SimulationManager.initialize`), and seeding uses
+> `seed.py --count`, not this value. Treat `NUMBER_OF_BINS` as reserved/unused
+> until a future component wires it in. *(TODO: confirm with team whether this
+> was intended to cap simulators or seed count.)*
+
+---
+
+## Config files in the repo
+
+| File | Tracked in git? | Used by | Notes |
+| --- | --- | --- | --- |
+| `services/data-simulator/.env.local.example` | ✅ yes | template only | Values for running natively (`POSTGRES_HOST=localhost`, `KAFKA_BOOTSTRAP_SERVERS=localhost:9092`). Copy to `.env.local`. |
+| `services/data-simulator/.env.docker` | ❌ **git-ignored** | `docker-compose.yml` (`env_file`) | Values for the Docker network (`POSTGRES_HOST=postgres`, `KAFKA_BOOTSTRAP_SERVERS=kafka:29092`). Exists locally but is **not** committed — see warning below. |
+| `services/data-simulator/.env.local` | ❌ git-ignored | `scripts/run_local.sh` (`source .env.local`) | Created by copying the example. |
+
+The `.gitignore` rule (repo root) is `.env*` with the single exception
+`!.env*.example`, so `.env.docker` and `.env.local` are both excluded from
+version control.
+
+> ### ⚠️ Discrepancy: `.env.docker` vs. the README quickstart
+>
+> `docker-compose.yml` reads `./services/data-simulator/.env.docker`
+> (`docker-compose.yml`, the `postgres` and `data_simulator` `env_file`
+> entries). But that file is **git-ignored**, so a fresh clone does not have it,
+> and the root `README.md` step 1 instead tells you to create
+> **`.env.docker.local`** — a filename Compose never references.
+>
+> **What actually works today:** Compose needs `.env.docker`. Either the file
+> already exists in your working copy (it does in this repo's local checkout),
+> or you must create it before `docker compose up`:
+>
+> ```bash
+> cp services/data-simulator/.env.local.example services/data-simulator/.env.docker
+> # then edit POSTGRES_HOST=postgres and KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+> ```
+>
+> This is flagged again in [troubleshooting.md](troubleshooting.md) and
+> [deployment.md](deployment.md). *(TODO: confirm with team which filename is
+> canonical and align README + compose + `.dockerignore`.)*
+
+Note: `.dockerignore` excludes all `.env.*` **except** `.env.docker`
+(`!.env.docker`), so `.env.docker` is intentionally included in the Docker
+build context even though it is git-ignored.
+
+---
+
+## Test-time configuration
+
+`tests/conftest.py:6-12` sets dummy values for all required keys at import time
+so that `Settings()` can be constructed without a real environment:
+
+```text
+POSTGRES_HOST=localhost   POSTGRES_PORT=5432   POSTGRES_DB=test_db
+POSTGRES_USER=test_user   POSTGRES_PASSWORD=test_password
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092   KAFKA_TOPIC=simulated_telemetry
+```
+
+CI additionally sets `PYTHONPATH=src` when running pytest
+(`.github/workflows/pr-pytest.yml:44`). See [testing.md](testing.md).
+
+---
+
+## Related documents
+
+- [database.md](database.md) — how `DATABASE_URL` is consumed.
+- [kafka.md](kafka.md) — how `KAFKA_*` values are consumed.
+- [deployment.md](deployment.md) — where each env file is injected.

--- a/docs/features/data-simulator/contributing.md
+++ b/docs/features/data-simulator/contributing.md
@@ -1,0 +1,155 @@
+# Contributing
+
+How to set up locally and the conventions this repo actually enforces. Where a
+convention is only *evidenced* (config present) versus *enforced* (a check
+fails), that distinction is called out.
+
+---
+
+## Local setup
+
+Prerequisites: Python 3.12, Docker + Docker Compose.
+
+```bash
+# 1. Clone and enter the service
+cd services/data-simulator
+
+# 2. Create a virtualenv and install dev deps (includes runtime deps)
+python3.12 -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\Activate.ps1
+pip install -r requirements-dev.txt
+
+# 3. Create your env files (git-ignored)
+cp .env.local.example .env.local           # for running natively
+cp .env.local.example .env.docker          # for the Docker stack (Compose reads this)
+#   .env.local  → POSTGRES_HOST=localhost, KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+#   .env.docker → POSTGRES_HOST=postgres,  KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+```
+
+> Why create `.env.docker` by hand: it is git-ignored yet Compose requires it,
+> and the README's `.env.docker.local` name is not the one Compose reads. See
+> [configuration.md](configuration.md).
+
+### Run it
+
+- **Full stack in Docker:** `docker compose up -d --build` (from repo root),
+  then seed + restart — see [deployment.md](deployment.md).
+- **Hybrid (infra in Docker, app on host):** `scripts/run_local.sh` /
+  `scripts/run_local.ps1`. If connecting the host app to the Dockerized
+  Postgres, note the host port is **5433** (see
+  [troubleshooting.md](troubleshooting.md)).
+
+### Run the tests
+
+```bash
+PYTHONPATH=src pytest -v
+```
+
+See [testing.md](testing.md).
+
+---
+
+## Coding conventions
+
+### Formatting / linting — Ruff
+
+`ruff.toml` (repo root):
+
+```toml
+line-length = 125
+
+[lint]
+select = ["E", "F"]
+ignore = []
+```
+
+Ruff (pycodestyle `E` + Pyflakes `F`) with a 125-char line limit. Run:
+
+```bash
+ruff check .        # lint
+ruff format .       # format (if you use Ruff's formatter)
+```
+
+> **Ruff is not enforced in CI.** No workflow runs it (see
+> [ci-cd.md](ci-cd.md)); it is a local/pre-commit gate only. Run it yourself
+> before pushing. The root README's claim that `act`/CI "runs the Ruff linter"
+> is inaccurate. *(TODO: confirm with team whether a Ruff CI step should be
+> added.)*
+
+### Type checking — mypy
+
+`mypy` is in `requirements-dev.txt`, but there is **no `mypy.ini` /
+`pyproject.toml` / `setup.cfg` mypy configuration** in the repo, and it does not
+run in CI. Type hints are used throughout `src/`, but type checking is currently
+ad-hoc. *(TODO: confirm with team whether mypy config/gating is intended.)*
+
+### pre-commit
+
+`pre-commit` is in `requirements-dev.txt`, but there is **no
+`.pre-commit-config.yaml`** in the repo — so `pre-commit install` has nothing to
+run yet. *(TODO: confirm with team whether a pre-commit config should be
+committed; the installed tool suggests it was planned.)*
+
+### Code style observed in `src/`
+
+Follow the existing style when adding code:
+
+- **Flat imports within `src/`** (e.g. `from config import get_settings`,
+  `from database import engine`) — enabled by `PYTHONPATH=src`. There is
+  intentionally no `__init__.py` in `src/`. Preserve this pattern; changing it
+  affects both runtime and the test import setup.
+- **Structured logging** via module-level `logger = logging.getLogger(__name__)`
+  and `%`-style lazy args (`logger.info("Started %d simulator(s).", n)`).
+- **Google-style docstrings** on classes/methods (see `models/bin.py`,
+  `bin_simulator.py`). New tests get a short docstring — `conftest.py` surfaces
+  its first line in `-v` output.
+- **Type hints** on signatures and attributes (`Mapped[...]`, `dict[str,
+  BinSimulator]`, `asyncio.Task | None`).
+- **Async I/O only** — never introduce blocking I/O into the event loop; use the
+  async engine / `aiokafka`.
+
+---
+
+## Branch naming & PR scope (enforced)
+
+CI **enforces** branch naming and file scope on PRs to `develop`
+(see [ci-cd.md](ci-cd.md)):
+
+- Feature branches: `feature/<service>/<task>` (e.g.
+  `feature/data-simulator/add-metrics`). The controller parses `<service>` and
+  `<task>`; an unrecognized prefix **fails the PR**.
+- A standard feature branch may modify **only** `services/<service>/**`.
+- A branch whose task is exactly `docs` (`feature/<service>/docs`) may modify
+  **only** `docs/features/<service>/**`.
+- Other recognized prefixes: `devops/…`, `platform/…`, `bugfix/…` (routing for
+  these is currently commented out in `pr-controller.yml`).
+
+So: keep code changes inside your service directory, and put documentation
+changes on a separate `.../docs` branch. Cross-cutting changes will be rejected
+by the feature-policy check.
+
+---
+
+## PR / review process
+
+- **Target branch:** open PRs against `develop` (that is what the workflows
+  trigger on).
+- **Required checks (intended):** **Feature Branch Policy** and **PR Pytest**
+  must pass. `pr-pytest-doc.md` recommends configuring these as required status
+  checks via branch protection.
+- **No `CODEOWNERS`, no pull-request template, and no `CONTRIBUTING.md`** exist
+  in the repo (verified). Review assignment/approval rules are therefore GitHub
+  repo settings, not committed policy. *(TODO: confirm with team the actual
+  review/approval requirements.)*
+
+Update docs alongside behavior changes — the docs index
+(`docs/features/README.md`) states documentation is treated as part of the
+source and PRs changing behavior should update the relevant docs.
+
+---
+
+## Related documents
+
+- [ci-cd.md](ci-cd.md) — the checks your PR must pass.
+- [testing.md](testing.md) — writing and running tests.
+- [project-structure.md](project-structure.md) — where new code belongs.

--- a/docs/features/data-simulator/database.md
+++ b/docs/features/data-simulator/database.md
@@ -1,0 +1,144 @@
+# Database
+
+The Data Simulator persists **only static bin metadata** in PostgreSQL. Dynamic
+telemetry (fill level, battery) is never written back to the database — it lives
+in memory and is emitted to Kafka. See
+[architecture.md](architecture.md#state-what-is-stateful-vs-stateless).
+
+- **Engine:** PostgreSQL 15 (`postgres:15-alpine`, `docker-compose.yml`).
+- **Driver:** async `asyncpg` via SQLAlchemy's async engine
+  (`postgresql+asyncpg://...`, see [configuration.md](configuration.md)).
+- Rationale for PostgreSQL: [decisions/002-postgresql.md](decisions/002-postgresql.md).
+
+---
+
+## Schema: the `smart_bins` table
+
+Defined by the `SmartBin` ORM model in `src/database.py:13-34`:
+
+| Column | Type | Constraints | Notes |
+| --- | --- | --- | --- |
+| `bin_id` | `String(50)` | **PRIMARY KEY** | Unique bin identifier (e.g. `BIN-1A2B3C4D-X`). |
+| `capacity` | `Float` | `NOT NULL` | Maximum fill capacity. Seeded as `100.0`. |
+| `latitude` | `Float` | `NOT NULL` | Geographic latitude. |
+| `longitude` | `Float` | `NOT NULL` | Geographic longitude. |
+| `status` | `String(20)` | `NOT NULL`, default `"ACTIVE"` | Only `ACTIVE` bins are simulated. |
+| `created_at` | `DateTime` | `NOT NULL`, server default `now()` | Set by the DB on insert. |
+| `updated_at` | `DateTime` | `NOT NULL`, server default `now()`, `onupdate=now()` | Refreshed by the DB on update. |
+
+The table name (`"smart_bins"`), the bounded `String(50)` primary key, the
+`"ACTIVE"` default, and the server-side timestamp defaults are all pinned by
+`tests/test_database.py`.
+
+> `status` has a **Python-side** default of `"ACTIVE"`
+> (`default="ACTIVE"`), asserted in `tests/test_database.py:76-80`. The
+> timestamp columns use **server-side** defaults (`server_default=func.now()`).
+
+---
+
+## How the schema is created — `create_tables.py` (no migrations)
+
+`src/create_tables.py` creates all tables directly from ORM metadata:
+
+```python
+async with engine.begin() as conn:
+    await conn.run_sync(Base.metadata.create_all)   # CREATE TABLE IF NOT EXISTS ...
+```
+
+`Base.metadata.create_all` is idempotent — it only creates tables that do not
+already exist and never alters existing ones. Run it as a one-off:
+
+```bash
+# inside the service directory, with env vars loaded and PYTHONPATH set
+PYTHONPATH=src python src/create_tables.py
+```
+
+> ### Migrations approach: there are none (yet)
+>
+> `alembic` is listed in `requirements.txt`, and the alembic CLI is installed in
+> the virtualenv, but **the service contains no `alembic/` directory,
+> `alembic.ini`, or version scripts** (`find services -iname '*alembic*'`
+> returns only virtualenv artifacts). The current schema-management strategy is
+> the create-only `create_tables.py` above.
+>
+> Practical consequence: **schema changes to `SmartBin` are not migrated.**
+> Adding/altering a column requires either dropping and recreating the table
+> (e.g. `docker compose down -v`, then re-create + re-seed) or introducing
+> Alembic. *(TODO: confirm with team whether Alembic is intended to be adopted;
+> the dependency suggests it was planned.)*
+
+Note also: nothing in `main.py`'s startup path calls `create_tables()`. The
+schema must exist **before** the simulator boots, which is why the quickstart
+seeds the DB in a separate step (see [operations.md](operations.md)).
+
+---
+
+## Seeding — `seed.py`
+
+`src/seed.py` is a standalone CLI (`argparse`) that inserts mock bins using
+`Faker`:
+
+```bash
+docker compose run --rm data_simulator python src/seed.py --count 50
+# reset first, then seed:
+docker compose run --rm data_simulator python src/seed.py --count 50 --clear
+```
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--count` | `50` | Number of bins to create. |
+| `--clear` | off | `DELETE FROM smart_bins` before inserting (`delete(SmartBin)`). |
+
+Each seeded row (`seed.py:32-41`):
+
+- `bin_id = f"BIN-{uuid.uuid4().hex[:8].upper()}-X"`
+- `capacity = 100.0`
+- `latitude = float(fake.latitude())`, `longitude = float(fake.longitude())`
+- `status = "ACTIVE"`
+
+**Safety guard:** requests over 500 bins are rejected before any DB connection
+is opened — "For safety, you cannot seed more than 500 bins at a time."
+(`seed.py:16-18`, verified by `tests/test_seed.py:88-99`).
+
+`seed.py` builds its **own** engine and session factory from `settings.DATABASE_URL`
+rather than importing `database.engine`, and always `await engine.dispose()`s in
+a `finally` block, even on error (`seed.py:21-48`).
+
+> Note: `seed.py` inserts rows but assumes the `smart_bins` table already
+> exists. It does **not** call `create_tables()`. If the table is missing,
+> seeding fails — create tables first (see [operations.md](operations.md)).
+
+---
+
+## ORM / query patterns actually used
+
+- **Async engine + session factory** (`src/database.py:37-43`):
+  `create_async_engine(settings.DATABASE_URL, echo=False)` and
+  `async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)`
+  exported as `AsyncSessionLocal`.
+- **Read (startup load)** — `SimulationManager.initialize`
+  (`simulation_manager.py:40-46`):
+  ```python
+  async with AsyncSessionLocal() as session:
+      result = await session.execute(
+          select(SmartBin).where(SmartBin.status == "ACTIVE")
+      )
+      db_bins = result.scalars().all()
+  ```
+- **Write (seeding)** — `session.add(new_bin)` in a loop, then
+  `await session.commit()` (`seed.py:41-43`).
+- **Delete (clear)** — `await session.execute(delete(SmartBin))` then commit
+  (`seed.py:26-29`).
+
+`expire_on_commit=False` keeps ORM attributes accessible after commit without
+triggering a refresh — relevant because the simulator copies bin fields into
+in-memory `Bin` objects.
+
+---
+
+## Related documents
+
+- [configuration.md](configuration.md) — `DATABASE_URL` construction.
+- [simulation-engine.md](simulation-engine.md) — how loaded bins become simulators.
+- [operations.md](operations.md) — create/seed/reset runbook.
+- [decisions/002-postgresql.md](decisions/002-postgresql.md) — why PostgreSQL.

--- a/docs/features/data-simulator/decisions/001-asyncio.md
+++ b/docs/features/data-simulator/decisions/001-asyncio.md
@@ -1,0 +1,74 @@
+# ADR 001: Use AsyncIO for concurrent bin simulation
+
+- **Status:** Accepted (reflects current implementation)
+- **Source note:** *Inferred from the codebase, not an original design record.*
+  No written ADR predates this file; the reasoning below is reconstructed from
+  code structure, docstrings, and dependencies. Points tied to specific code are
+  cited; the rest is inferred.
+
+---
+
+## Context
+
+The service must simulate a large fleet of smart bins **concurrently**, each
+emitting telemetry on a fixed interval (`SIMULATION_INTERVAL`, default 5s). The
+per-bin workload is almost entirely I/O-bound waiting: sleep between ticks, then
+`await` a network publish to Kafka; the actual computation (`_simulate`,
+`to_payload`) is trivial. The dependencies are async-native — `aiokafka` and
+SQLAlchemy's async engine with `asyncpg` (`requirements.txt`).
+
+Options for concurrency:
+
+1. **Threads** — one thread per bin.
+2. **Processes** — one process per bin (or a pool).
+3. **AsyncIO** — one event loop, one task per bin.
+
+## Decision
+
+Use a single-process **asyncio** model: one event loop, one `asyncio.Task` per
+bin.
+
+Evidence in code:
+
+- `main()` is `async` and launched with `asyncio.run(main())`
+  (`src/main.py:17, 72`).
+- Each `BinSimulator.start()` schedules its loop as a task —
+  `self._task = asyncio.create_task(self._run())` (`bin_simulator.py:74`) — and
+  `_run()` `await`s Kafka then `asyncio.sleep(SIMULATION_INTERVAL)`
+  (`bin_simulator.py:131-142`).
+- I/O libraries are async: `AIOKafkaProducer` (`kafka_producer.py`) and
+  `create_async_engine(... postgresql+asyncpg ...)` (`database.py`,
+  `config.py`).
+- Shutdown is coordinated with an `asyncio.Event` and
+  `loop.add_signal_handler` (`main.py:35-48`).
+
+## Consequences
+
+**Positive**
+
+- Thousands of mostly-idle bins are cheap: an idle task parked on
+  `asyncio.sleep` costs far less than a thread or process.
+- No shared-state locking: all tasks run cooperatively on one thread, so the
+  in-memory registry and per-bin state need no mutexes.
+- Clean, deterministic shutdown: cancel every task, await it, dispose resources
+  under explicit timeouts (`main.py:52-68`).
+- Matches the async I/O stack (`aiokafka`, `asyncpg`) end-to-end.
+
+**Negative / trade-offs**
+
+- **No CPU parallelism.** A single event loop uses one core; any CPU-heavy
+  simulation added later would block all bins. The current `_simulate` math is
+  cheap, so this is acceptable today.
+- **Blocking calls are hazardous.** Introducing synchronous I/O (a blocking DB
+  driver, `time.sleep`, `requests`) would stall every bin. Contributors must
+  keep the loop non-blocking (noted in [contributing.md](../contributing.md)).
+- **Single-process scaling ceiling.** Scaling beyond one process needs bin
+  partitioning across instances, which is not implemented
+  (see [operations.md](../operations.md#scaling)).
+- Platform nuance: signal handling differs on Windows, handled explicitly
+  (`main.py:42-48`).
+
+## Related
+
+- [simulation-engine.md](../simulation-engine.md),
+  [architecture.md](../architecture.md#concurrency-what-is-async-vs-sync).

--- a/docs/features/data-simulator/decisions/002-postgresql.md
+++ b/docs/features/data-simulator/decisions/002-postgresql.md
@@ -1,0 +1,78 @@
+# ADR 002: Use PostgreSQL for bin metadata
+
+- **Status:** Accepted (reflects current implementation)
+- **Source note:** *Inferred from the codebase, not an original design record.*
+  Reconstructed from code, config, and dependencies; code-tied points are cited.
+
+---
+
+## Context
+
+The simulator needs durable storage for the **static identity and metadata** of
+each bin — `bin_id`, `capacity`, `latitude`, `longitude`, `status`, timestamps
+(`SmartBin`, `src/database.py:13-34`). This data is:
+
+- Read once at startup to spawn simulators
+  (`SimulationManager.initialize`, `simulation_manager.py:40-46`).
+- Relational and well-structured (fixed columns, a natural primary key
+  `bin_id`), with a `status` field used to filter which bins are active.
+
+Crucially, **dynamic telemetry is not stored here** — it is in-memory and
+streamed to Kafka (`Bin` docstring, `database.py:14-20`). So the datastore's job
+is a modest, mostly-read metadata catalog, not a high-write time-series sink.
+
+## Decision
+
+Use **PostgreSQL 15** as the metadata store, accessed via SQLAlchemy's async
+ORM over the `asyncpg` driver.
+
+Evidence in code / config:
+
+- `postgres:15-alpine` in `docker-compose.yml` (service `postgres`,
+  `smartbin_postgres`).
+- `DATABASE_URL = postgresql+asyncpg://...` computed in `config.py:19-27`;
+  `create_async_engine(...)` in `database.py:38`.
+- Declarative ORM model `SmartBin` mapping to table `smart_bins`
+  (`database.py:13-34`).
+- `asyncpg` + `SQLAlchemy` in `requirements.txt`.
+
+## Consequences
+
+**Positive**
+
+- Strong relational schema with constraints (non-null columns, bounded
+  `String(50)` PK, server-side timestamp defaults) — enforced by the DB and
+  verified in `tests/test_database.py`.
+- Async driver (`asyncpg`) fits the asyncio architecture
+  (see [ADR 001](001-asyncio.md)) without blocking the event loop.
+- Ubiquitous, well-understood, easy to run locally via the Alpine image and
+  inspect with `psql`.
+- Clean separation of concerns: durable *identity* in Postgres, ephemeral
+  *state* in memory, durable *stream* in Kafka
+  (see [architecture.md](../architecture.md#state-what-is-stateful-vs-stateless)).
+
+**Negative / trade-offs**
+
+- **Schema evolution is unmanaged.** There are no Alembic migrations despite
+  `alembic` being a dependency; tables are created with
+  `Base.metadata.create_all` via `create_tables.py`, which never alters existing
+  tables (see [database.md](../database.md)). Column changes require a manual
+  drop/recreate today. *(TODO: confirm with team whether Alembic adoption is
+  intended.)*
+- **Single-node, RF-agnostic.** The compose setup is one Postgres node with a
+  local volume — no HA/replication. Fine for simulation, not production-grade.
+- Operational cost of a full relational DB for what is currently a small,
+  read-mostly catalog — justified by the relational fit and room to grow (the
+  commented-out CRUD/FastAPI plans in `simulation_manager.py:67` imply future
+  read/write use).
+
+## Alternatives considered (inferred)
+
+- **SQLite / a flat file:** simpler, but weaker concurrency story and a poor fit
+  for the intended future networked CRUD layer.
+- **A NoSQL/document store:** unnecessary — the data is naturally tabular with a
+  clear primary key and a filterable `status`.
+
+## Related
+
+- [database.md](../database.md), [configuration.md](../configuration.md).

--- a/docs/features/data-simulator/decisions/003-kafka.md
+++ b/docs/features/data-simulator/decisions/003-kafka.md
@@ -1,0 +1,87 @@
+# ADR 003: Use Apache Kafka for telemetry streaming
+
+- **Status:** Accepted (reflects current implementation)
+- **Source note:** *Inferred from the codebase, not an original design record.*
+  Reconstructed from code, `docker-compose.yml`, and dependencies; code-tied
+  points are cited.
+
+---
+
+## Context
+
+The simulator continuously emits per-bin telemetry snapshots (fill level,
+battery, location, timestamp) that downstream consumers — dashboards,
+alerting, analytics — will want to read independently and in real time. The
+producer generates one message per bin per `SIMULATION_INTERVAL`; the volume
+scales with the fleet size.
+
+Requirements implied by the design:
+
+- A **decoupled** transport so the simulator does not know or wait on
+  consumers.
+- **Per-bin ordering** (a bin's snapshots should stay in order).
+- Real-time fan-out to multiple/independent consumers.
+- Full snapshots each tick, so occasional loss is tolerable
+  (see [kafka.md](../kafka.md#delivery-guarantees-as-actually-configured)).
+
+## Decision
+
+Use **Apache Kafka** (Confluent `cp-kafka:7.4.1`, **KRaft mode** — no
+ZooKeeper) as the streaming backbone, with the simulator acting as a
+**producer only**.
+
+Evidence in code / config:
+
+- `kafka` service in `docker-compose.yml` with `KAFKA_PROCESS_ROLES:
+  'broker,controller'` (KRaft), internal listener `kafka:29092` and host
+  listener `localhost:9092`.
+- `KafkaClient` wrapping `AIOKafkaProducer` (`kafka_producer.py`), JSON value
+  serializer, publishing to `KAFKA_TOPIC` (`smartbin-telemetry-v1`) **keyed by
+  `bin_id`** (`kafka_producer.py:58-59`).
+- `aiokafka` in `requirements.txt`.
+- No consumer anywhere in `src/` — the service only produces.
+
+## Consequences
+
+**Positive**
+
+- **Producer/consumer decoupling:** the simulator publishes and moves on; any
+  number of consumers can subscribe without changing it.
+- **Per-bin ordering:** keying by `bin_id` routes each bin's messages to one
+  partition, preserving order per bin.
+- **Real-time, replayable log:** consumers can read live or from history and can
+  join/leave independently.
+- **KRaft simplifies ops:** no ZooKeeper to run — a single container is the
+  whole broker.
+- The async producer (`aiokafka`) fits the asyncio model
+  (see [ADR 001](001-asyncio.md)).
+
+**Negative / trade-offs**
+
+- **Operational weight** of a broker for a simulator — heavier than, say, a
+  simple queue or direct DB writes. Justified by the real-time fan-out and
+  ordering needs.
+- **Best-effort delivery as configured:** default `acks`, no idempotence, no
+  producer retries; failed sends are logged and dropped
+  (`kafka_producer.py:61-62`). Acceptable because each tick re-sends full state,
+  but not suitable if exactly-once/durable delivery is later required.
+- **Single-node, RF 1** in the compose setup — no broker HA
+  (`KAFKA_*_REPLICATION_FACTOR: 1`).
+- **Topic auto-creation** is relied upon rather than explicit provisioning
+  (see [kafka.md](../kafka.md#topics)). *(TODO: confirm intended.)*
+- **Schema is implicit** (plain JSON, no schema registry) — consumers must track
+  the payload shape out of band; the `-v1` topic suffix is the only versioning
+  signal.
+
+## Alternatives considered (inferred)
+
+- **Direct DB writes of telemetry:** rejected — would make Postgres a
+  high-write time-series sink and couple producers to consumers; contradicts the
+  explicit "telemetry is not persisted to the DB" design.
+- **A simple message queue (e.g. RabbitMQ):** weaker on replay, multi-consumer
+  fan-out, and partition-based ordering guarantees for a streaming workload.
+
+## Related
+
+- [kafka.md](../kafka.md), [architecture.md](../architecture.md),
+  [simulation-engine.md](../simulation-engine.md).

--- a/docs/features/data-simulator/decisions/004-simulation-manager.md
+++ b/docs/features/data-simulator/decisions/004-simulation-manager.md
@@ -1,0 +1,78 @@
+# ADR 004: Centralize simulator lifecycles in a SimulationManager
+
+- **Status:** Accepted (reflects current implementation)
+- **Source note:** *Inferred from the codebase, not an original design record.*
+  Reconstructed from code, docstrings, and inline comments; code-tied points are
+  cited.
+
+---
+
+## Context
+
+The service runs many independent per-bin simulators concurrently
+(see [ADR 001](001-asyncio.md)). Something has to:
+
+- create one simulator per `ACTIVE` bin at startup,
+- keep a registry so bins can be looked up, added, updated, and removed,
+- and shut every simulator down cleanly on exit.
+
+Left to `main()`, this orchestration would sprawl. A three-layer separation
+already exists in the code:
+
+- `Bin` (`models/bin.py`) — pure state + payload, no infrastructure.
+- `BinSimulator` (`simulator/bin_simulator.py`) — the async loop for **one**
+  bin.
+- A coordinator for **all** bins — the gap this ADR fills.
+
+## Decision
+
+Introduce **`SimulationManager`** (`simulator/simulation_manager.py`) as the
+single owner of all `BinSimulator` instances, backed by an in-memory
+`dict[str, BinSimulator]` keyed by `bin_id`.
+
+Evidence in code:
+
+- `_simulators: dict[str, BinSimulator]` registry (`simulation_manager.py:32`).
+- `initialize()` loads ACTIVE bins and starts a simulator per bin
+  (`:34-65`); `main()` calls exactly this at startup (`main.py:29-30`).
+- Lifecycle API: `add_bin`, `remove_bin`, `update_bin`, `stop`,
+  `get_simulator`, `exists`, `simulators` (`:68-208`).
+- `main()` delegates shutdown to `manager.stop()` (`main.py:54`), which stops
+  every simulator and clears the registry (`:155-169`).
+- The domain model is deliberately infrastructure-free, keeping the manager the
+  only place that touches the DB for bin loading (`Bin` docstring,
+  `models/bin.py:6-18`).
+
+## Consequences
+
+**Positive**
+
+- **Single source of truth** for which bins are simulating — clean lookups
+  (`get_simulator`/`exists`) and a clean teardown path.
+- **Clear layering:** state (`Bin`) vs. per-bin loop (`BinSimulator`) vs.
+  fleet coordination (`SimulationManager`). Each is unit-tested in isolation
+  (`tests/models/`, `tests/simulator/`).
+- **Extensible:** `add_bin`/`update_bin`/`remove_bin` give a ready CRUD surface
+  for a future control plane.
+- Keeps `main()` thin — orchestration lives in the manager, not the entrypoint.
+
+**Negative / trade-offs**
+
+- **In-memory, single-process registry.** State is not shared across processes,
+  so it reinforces the single-instance constraint — a second instance would
+  duplicate the whole fleet (see [operations.md](../operations.md#scaling)).
+- **Startup-only population.** `initialize()` loads bins **once**; there is no
+  reconciliation loop, so DB changes after boot are invisible until restart.
+- **CRUD API is dormant.** `add_bin`/`update_bin`/`remove_bin` are implemented
+  and tested but **not wired to any trigger** — the code marks this explicitly:
+  "Add, update, delete - need to be implemented with Fast API in future
+  involving DB interaction" (`simulation_manager.py:67`). Until that control
+  plane exists, these methods are latent.
+- **No persistence of runtime state.** Losing the process loses the registry and
+  all in-memory bin state (rebuilt from the DB on next start) — acceptable given
+  telemetry is streamed, not stored.
+
+## Related
+
+- [simulation-engine.md](../simulation-engine.md#the-registry-simulationmanager),
+  [architecture.md](../architecture.md), [ADR 001](001-asyncio.md).

--- a/docs/features/data-simulator/deployment.md
+++ b/docs/features/data-simulator/deployment.md
@@ -1,0 +1,139 @@
+# Deployment
+
+The Data Simulator is deployed with **Docker Compose**. There are no Kubernetes
+manifests, Helm charts, or cloud/IaC files in the repository — the only
+deployment artifacts are `docker-compose.yml` (repo root) and the service
+`Dockerfile`. This document describes what those actually define.
+
+> There is no automated deploy in CI. The GitHub Actions workflows run tests and
+> policy checks only — they do **not** build or push images or deploy anywhere.
+> See [ci-cd.md](ci-cd.md).
+
+---
+
+## The Docker stack (`docker-compose.yml`)
+
+Three services plus one named volume:
+
+| Service | Image / build | Container name | Ports (host:container) | Notes |
+| --- | --- | --- | --- | --- |
+| `postgres` | `postgres:15-alpine` | `smartbin_postgres` | `5433:5432` | `env_file: ./services/data-simulator/.env.docker`; healthcheck via `pg_isready`; data in named volume `postgres_data`. |
+| `kafka` | `confluentinc/cp-kafka:7.4.1` | `smartbin_kafka` | `9092:9092`, `9093:9093` | KRaft mode (no ZooKeeper). Listeners: `kafka:29092` (internal), `localhost:9092` (host). See [kafka.md](kafka.md). |
+| `data_simulator` | build `./services/data-simulator/Dockerfile` | `data_simulator` | none | `env_file: ./services/data-simulator/.env.docker`; `depends_on: postgres (service_healthy)`. |
+
+Key details verified in `docker-compose.yml`:
+
+- **Postgres is published on host port `5433`** (mapped to container `5432`) to
+  avoid clashing with a local Postgres. Inside the compose network other
+  services still reach it as `postgres:5432`.
+- **`data_simulator` waits for Postgres health** (`condition:
+  service_healthy`), but has **no `depends_on` for `kafka`**. The producer's own
+  10× retry loop covers the case where Kafka is still coming up
+  (see [kafka.md](kafka.md)).
+- The Postgres healthcheck uses `POSTGRES_USER`/`POSTGRES_DB` (defaulting to
+  `postgres` / `smart_city`) supplied from `.env.docker`.
+
+---
+
+## The image (`services/data-simulator/Dockerfile`)
+
+Multi-stage build on `python:3.12-slim`:
+
+```text
+base     → installs gcc; sets PYTHONUNBUFFERED, PYTHONDONTWRITEBYTECODE, PYTHONPATH=/app
+  ├─ test    → installs requirements-dev.txt, copies source, RUN pytest
+  └─ runtime → installs requirements.txt, copies source, CMD ["python", "src/main.py"]
+```
+
+- `PYTHONPATH=/app` is what makes the flat imports in `src/` (e.g.
+  `from config import get_settings`) resolve when the process runs
+  `python src/main.py`.
+- The `test` stage runs `pytest` **at build time** — building that target fails
+  the build if tests fail. Compose builds the default (last) stage, which is
+  `runtime`; to build/run the test stage explicitly:
+  `docker build --target test services/data-simulator`.
+- `.dockerignore` trims the build context (`.venv/`, `__pycache__/`, `logs/`,
+  `.git`, most `.env.*`) but **keeps `.env.docker`** (`!.env.docker`).
+
+---
+
+## Environments
+
+There are two documented run modes; there is **no separate staging/production
+environment defined in the repo.**
+
+### 1. Full Docker stack (everything in containers)
+
+Uses `.env.docker` (`POSTGRES_HOST=postgres`, `KAFKA_BOOTSTRAP_SERVERS=kafka:29092`).
+This is the mode `docker-compose.yml` is wired for.
+
+### 2. Hybrid local (infra in Docker, simulator on host)
+
+`scripts/run_local.sh` (Linux/macOS) and `scripts/run_local.ps1` (Windows):
+
+- Bring up **only** `postgres` and `kafka`:
+  `docker compose -f docker-compose.yml up -d postgres kafka`.
+- Wait for Postgres via `docker exec smartbin_postgres pg_isready`.
+- `source .env.local` (host values: `localhost:9092`, `localhost:5432` — note
+  the script's `.env.local` still uses `5432`, whereas Docker publishes Postgres
+  on **5433**; see the warning in [troubleshooting.md](troubleshooting.md)).
+- Run `PYTHONPATH=. python src/main.py` on the host.
+
+This mode is for debugging in an IDE without rebuilding images.
+
+---
+
+## Rollout / operational lifecycle
+
+There is no blue-green, canary, or orchestrated rollout — deployment is
+Compose lifecycle commands. Verified from the root `README.md` and
+`docker-compose.yml`:
+
+```bash
+# 0. (First time) ensure the env file Compose reads actually exists — see warning below
+# 1. Build + start the stack
+docker compose up -d --build
+
+# 2. Create schema + seed data (one-off container). The simulator emits nothing
+#    until the DB has ACTIVE bins.
+docker compose run --rm data_simulator python src/seed.py --count 50
+
+# 3. Restart the simulator to pick up the seeded bins (it loads bins once, at boot)
+docker compose restart data_simulator
+
+# Stop
+docker compose down
+
+# Hard reset (also drops the postgres_data volume — wipes all bins)
+docker compose down -v
+```
+
+Step 3 is required because `SimulationManager.initialize()` loads bins **once**
+at startup; seeding after boot has no effect until a restart
+(see [simulation-engine.md](simulation-engine.md)). Day-2 operations —
+monitoring, scaling, restarts — are in [operations.md](operations.md).
+
+> ### ⚠️ Required env file before first `up`
+>
+> `docker-compose.yml` reads `./services/data-simulator/.env.docker`, but that
+> file is **git-ignored** and the README instead references `.env.docker.local`
+> (which Compose does not use). On a fresh clone, create `.env.docker` first or
+> `docker compose up` fails on the missing `env_file`:
+>
+> ```bash
+> cp services/data-simulator/.env.local.example services/data-simulator/.env.docker
+> # set POSTGRES_HOST=postgres and KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+> ```
+>
+> Full analysis of this discrepancy is in
+> [configuration.md](configuration.md) and
+> [troubleshooting.md](troubleshooting.md). *(TODO: confirm with team.)*
+
+---
+
+## Related documents
+
+- [configuration.md](configuration.md) — env vars and env files.
+- [operations.md](operations.md) — running, monitoring, scaling, resetting.
+- [kafka.md](kafka.md) — broker/listener configuration.
+- [ci-cd.md](ci-cd.md) — what CI does (and does not) do for deployment.

--- a/docs/features/data-simulator/kafka.md
+++ b/docs/features/data-simulator/kafka.md
@@ -1,0 +1,166 @@
+# Kafka
+
+The Data Simulator is a **Kafka producer only** — it publishes telemetry and
+consumes nothing. Messaging is handled by `aiokafka`'s `AIOKafkaProducer`,
+wrapped in a singleton `KafkaClient` (`src/kafka_producer.py`). Rationale for
+choosing Kafka: [decisions/003-kafka.md](decisions/003-kafka.md).
+
+---
+
+## Broker
+
+Defined in `docker-compose.yml` as service `kafka`
+(`confluentinc/cp-kafka:7.4.1`) running in **KRaft mode** (`KAFKA_PROCESS_ROLES:
+'broker,controller'`) — no ZooKeeper. Single-node, replication factor 1
+throughout (`KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1`,
+`KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1`).
+
+### Listeners
+
+| Listener | Address | Used by |
+| --- | --- | --- |
+| `PLAINTEXT` (internal) | `kafka:29092` | Other containers on the compose network (the simulator) |
+| `PLAINTEXT_HOST` (external) | `localhost:9092` | Tools on the host machine |
+| `CONTROLLER` | `kafka:29093` | KRaft controller quorum |
+
+So the simulator container connects to `kafka:29092`
+(`.env.docker` → `KAFKA_BOOTSTRAP_SERVERS=kafka:29092`), while host tools such
+as `kafka-console-consumer` or a natively-run simulator use `localhost:9092`
+(`.env.local.example`).
+
+---
+
+## Topics
+
+| Topic | Direction | Where set |
+| --- | --- | --- |
+| `smartbin-telemetry-v1` | **Produced** | `KAFKA_TOPIC` env var (`.env.docker`, `.env.local.example`) |
+
+The service **consumes no topics** — there is no consumer, no consumer group,
+and no `aiokafka.AIOKafkaConsumer` anywhere in `src/`.
+
+> **Topics are not pre-declared.** `docker-compose.yml` does not create the
+> topic, and the producer does not explicitly create it either. With the default
+> Confluent broker settings, `smartbin-telemetry-v1` is auto-created on first
+> produce (single partition, RF 1). *(TODO: confirm with team whether relying on
+> auto-create is intended vs. an explicit topic-provisioning step.)*
+
+---
+
+## Message schema
+
+The producer serializes the dict returned by `Bin.to_payload()` as UTF-8 JSON.
+Full field list and rounding rules: see
+[simulation-engine.md](simulation-engine.md). Example value:
+
+```json
+{
+  "bin_id": "BIN-1A2B3C4D-X",
+  "capacity": 100.0,
+  "current_fill_level": 42.37,
+  "battery_level": 98.61,
+  "latitude": 40.1234,
+  "longitude": -73.9876,
+  "timestamp": "2026-08-02T12:34:56.789012+00:00"
+}
+```
+
+- **Value:** `json.dumps(payload).encode("utf-8")` via the producer's
+  `value_serializer` (`kafka_producer.py:25`).
+- **Key:** the `bin_id`, encoded as UTF-8 bytes —
+  `key=bin_id.encode("utf-8")` (`kafka_producer.py:59`). Keying by `bin_id`
+  means all telemetry for a given bin lands on the same partition, preserving
+  per-bin ordering. Verified by `tests/test_kafka_producer.py:79-99`.
+- **Headers / schema registry:** none. Plain JSON, no Avro/Protobuf, no schema
+  registry configured.
+
+The `-v1` suffix in the topic name is the versioning convention — a breaking
+payload change would move to a new topic (e.g. `smartbin-telemetry-v2`).
+
+---
+
+## Producer setup
+
+`KafkaClient.start()` (`src/kafka_producer.py:15-44`):
+
+```python
+self.producer = AIOKafkaProducer(
+    bootstrap_servers=settings.KAFKA_BOOTSTRAP_SERVERS,
+    value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+)
+await self.producer.start()
+```
+
+- **Connection retries:** up to 10 attempts, 3 seconds apart. On each failed
+  attempt a partially-constructed producer is stopped (errors swallowed) before
+  retrying. After 10 failures it raises
+  `"Could not connect to Kafka on {servers} after multiple retries"`
+  (`kafka_producer.py:16-44`, tested at `test_kafka_producer.py:29-77`). This
+  tolerates the broker still starting up when the simulator boots.
+- **Singleton:** `kafka_client = KafkaClient()` at module scope
+  (`kafka_producer.py:65`) — the same instance is imported by `main.py` and
+  `bin_simulator.py`.
+
+---
+
+## Delivery guarantees (as actually configured)
+
+Send path — `KafkaClient.send_telemetry()` (`kafka_producer.py:51-62`):
+
+```python
+await self.producer.send_and_wait(
+    topic=settings.KAFKA_TOPIC, value=payload, key=bin_id.encode("utf-8")
+)
+```
+
+- **`send_and_wait`** waits for the broker acknowledgement before returning, so
+  each publish is synchronous from the caller's perspective (no fire-and-forget
+  batching gap left unresolved before the next tick).
+- **`acks` is not set explicitly**, so `aiokafka`'s default applies
+  (`acks=1` — leader acknowledgement). With single-node RF 1 there are no
+  followers regardless.
+- **No retries/idempotence configured** on the producer (`enable_idempotence`,
+  `acks="all"`, transactions are all unset). Effective guarantee is roughly
+  **at-most-once from the application's point of view**: on a send failure the
+  exception is caught, an error is logged, and the message is **dropped** — the
+  loop moves on rather than retrying (`kafka_producer.py:61-62`).
+- **If the producer was never started**, `send_telemetry` logs
+  `"Kafka producer is not started; dropping telemetry for {bin_id}"` and returns
+  without raising (`kafka_producer.py:52-56`, tested at
+  `test_kafka_producer.py:101-109`).
+
+> **Net effect:** telemetry is best-effort. Because the simulator regenerates
+> state every `SIMULATION_INTERVAL` seconds and emits a full snapshot each time,
+> a dropped message is self-healing on the next tick — losing one payload is not
+> critical for this workload. If stronger guarantees are needed, set
+> `acks="all"`, `enable_idempotence=True`, and add producer-side retries.
+
+---
+
+## Shutdown
+
+`KafkaClient.stop()` calls `producer.stop()` (which flushes pending messages and
+closes the connection) and logs `"Kafka producer stopped"`; it is a safe no-op
+if no producer was started (`kafka_producer.py:46-49`). Called from `main.py`
+during graceful shutdown under a 5-second timeout.
+
+---
+
+## Consuming the stream (for verification)
+
+From the host, against the external listener:
+
+```bash
+docker exec -it smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-v1
+```
+
+More verification commands: [operations.md](operations.md).
+
+---
+
+## Related documents
+
+- [simulation-engine.md](simulation-engine.md) — how payloads are generated.
+- [configuration.md](configuration.md) — `KAFKA_*` env vars.
+- [decisions/003-kafka.md](decisions/003-kafka.md) — why Kafka.

--- a/docs/features/data-simulator/operations.md
+++ b/docs/features/data-simulator/operations.md
@@ -1,0 +1,188 @@
+# Operations
+
+Runbook for operating the Data Simulator via Docker Compose. All commands are
+verified against `docker-compose.yml`, the root `README.md`, and the service
+source.
+
+> Scope note: this service has **no HTTP endpoint, no metrics endpoint, and no
+> configured alerting**. "Monitoring" today means logs and manual data checks.
+> Anything requiring infrastructure that does not exist in the repo is marked
+> **TODO: confirm with team**.
+
+---
+
+## Start / stop
+
+```bash
+# Build + start the whole stack
+docker compose up -d --build
+
+# Start infra only (for hybrid local dev), then run the simulator on the host
+services/data-simulator/scripts/run_local.sh      # Linux/macOS
+services/data-simulator/scripts/run_local.ps1     # Windows
+
+# Stop the stack (keeps data)
+docker compose down
+
+# Stop + wipe all data (drops the postgres_data volume)
+docker compose down -v
+```
+
+First-run prerequisite: the `.env.docker` file must exist — see the warning in
+[deployment.md](deployment.md) and [configuration.md](configuration.md).
+
+---
+
+## First-run data setup
+
+The simulator emits nothing until the `smart_bins` table exists and has `ACTIVE`
+rows. `seed.py` inserts rows but does **not** create the table
+(see [database.md](database.md)).
+
+```bash
+# (if the table doesn't exist yet) create schema
+docker compose run --rm data_simulator python src/create_tables.py
+
+# seed mock bins (max 500)
+docker compose run --rm data_simulator python src/seed.py --count 50
+
+# reset + reseed
+docker compose run --rm data_simulator python src/seed.py --count 50 --clear
+
+# apply the new bins (simulator loads bins only at startup)
+docker compose restart data_simulator
+```
+
+> The root README's quickstart runs `seed.py` directly and relies on the table
+> already existing. If seeding fails with an "undefined table" error, run
+> `create_tables.py` first.
+
+---
+
+## Monitoring
+
+### Logs
+
+Logging is configured in `src/logging_config.py`:
+
+- **Console:** colorized (`colorlog`), format
+  `%(asctime)s | %(levelname)-8s | %(name)s | %(message)s`.
+- **File:** `logs/simulator.log`, a `RotatingFileHandler` — **20 MB per file, 5
+  backups** (`logging_config.py:41-45`). Inside the container this is
+  `/app/logs/simulator.log`; it is **not** a mounted volume, so it lives in the
+  container's writable layer and is lost when the container is removed.
+- Default level **INFO**; `aiokafka.cluster` is pinned to CRITICAL to reduce
+  noise (`logging_config.py:52`).
+
+```bash
+# follow container stdout/stderr (console handler)
+docker logs data_simulator -f
+
+# tail the rotating file inside the container
+docker exec -it data_simulator tail -f logs/simulator.log
+```
+
+Healthy startup logs (from `src/main.py`): `Initializing Data Simulator` →
+`Kafka Client Started Successfully` → `Simulation Manager Started Successfully`,
+followed by `Started N simulator(s).` from the manager.
+
+### Toggle DEBUG at runtime (no restart)
+
+`setup_logging` registers a **SIGUSR1** handler that flips the root level
+between INFO and DEBUG (`logging_config.py:55, 60-71`). At DEBUG you get
+per-bin `Sending telemetry` / `Simulated bin ... | Fill: .. | Battery: ..`
+lines.
+
+```bash
+# send SIGUSR1 to PID 1 (the python process) in the container
+docker exec data_simulator kill -USR1 1
+```
+
+Send it again to go back to INFO. *(Linux/macOS only — SIGUSR1 does not exist on
+Windows.)*
+
+### Verify the database
+
+```bash
+docker exec -it smartbin_postgres psql -U postgres -d smart_city \
+  -c "SELECT bin_id, capacity, latitude, longitude, status FROM smart_bins LIMIT 10;"
+```
+
+(Host access: Postgres is published on `localhost:5433`.)
+
+### Verify the Kafka stream
+
+```bash
+docker exec -it smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-v1
+```
+
+You should see one JSON telemetry message per bin roughly every
+`SIMULATION_INTERVAL` (default 5s). See [kafka.md](kafka.md).
+
+---
+
+## Restart
+
+```bash
+docker compose restart data_simulator
+```
+
+The container handles **SIGTERM** gracefully: `main.py` cancels all simulators,
+stops the Kafka producer (flush), and disposes the DB engine, each under a 5s
+timeout (`src/main.py:52-68`). Compose's default stop grace period (10s) is
+comfortably above that. Restarting is also the supported way to pick up newly
+seeded bins.
+
+---
+
+## Scaling
+
+**Vertical (more bins, same process):** seed more `ACTIVE` bins and restart.
+Concurrency is asyncio on a single event loop, so a single container simulates
+many bins cheaply (each bin is one lightweight task). Practical ceilings:
+
+- `seed.py` caps a single seed run at **500 bins** (`seed.py:16-18`). Run it
+  multiple times, or raise the guard, for more.
+- CPU/throughput ceiling is undocumented — no load test exists in the repo.
+  *(TODO: confirm with team the tested upper bound on bins per container.)*
+
+**Horizontal (multiple simulator containers):** **not supported as-is.** Every
+instance would call `SimulationManager.initialize()` and load the **same** set
+of `ACTIVE` bins from the shared DB, producing duplicate telemetry for every
+bin. There is no sharding/partitioning of bins across instances. Do not scale
+`data_simulator` to replicas > 1 without adding bin-partitioning logic.
+*(TODO: confirm with team if horizontal scale is on the roadmap.)*
+
+`NUMBER_OF_BINS` does **not** control scale — it is unused
+(see [configuration.md](configuration.md)).
+
+---
+
+## Alerts
+
+**None configured.** There is no metrics endpoint, no Prometheus/Grafana, and no
+alerting wired in the repo. Operational awareness is currently manual (logs +
+DB/topic checks above). *(TODO: confirm with team whether alerting/metrics are
+planned — a candidate first metric is "telemetry send failures", already logged
+as `Failed to send telemetry for <bin_id>`.)*
+
+Failure signals to watch for in logs:
+
+| Log line | Meaning |
+| --- | --- |
+| `Kafka not ready yet (...), retrying... (i/10)` | Producer still connecting; normal at boot, a problem if it repeats past ~30s. |
+| `Could not connect to Kafka ... after multiple retries` | Producer gave up after 10 attempts → the process raises and exits. |
+| `Kafka producer is not started; dropping telemetry for <bin>` | Telemetry produced before the client started. |
+| `Failed to send telemetry for <bin>: ...` | A publish was dropped (best-effort delivery). |
+| `Started 0 simulator(s).` | No ACTIVE bins in the DB — seed data. |
+
+More symptom→cause→fix mappings: [troubleshooting.md](troubleshooting.md).
+
+---
+
+## Related documents
+
+- [deployment.md](deployment.md) — stack topology and lifecycle.
+- [database.md](database.md) — schema, create, seed, reset.
+- [troubleshooting.md](troubleshooting.md) — failure modes.

--- a/docs/features/data-simulator/project-structure.md
+++ b/docs/features/data-simulator/project-structure.md
@@ -1,0 +1,109 @@
+# Project Structure
+
+This document is an annotated map of the Data Simulator service and the
+repository directories that support it. Every path below was verified against
+the repository tree; unless noted otherwise, paths are relative to the repo
+root.
+
+---
+
+## Repository top level
+
+```text
+smart_city_trash_bin_monitor/
+├── docker-compose.yml            # Unified local stack: postgres + kafka + data_simulator
+├── ruff.toml                     # Ruff linter config (line-length 125, E/F rules)
+├── event.json                    # Sample GitHub PR event, used for local CI runs via `act`
+├── README.md                     # Root project readme + quickstart
+├── .github/workflows/            # CI pipelines (governance controller, feature policy, pytest)
+├── docs/features/                # Per-feature documentation (this directory tree)
+├── services/
+│   └── data-simulator/           # The Data Simulator service (all runtime code)
+└── binforge/                     # Legacy prototype — NOT git-tracked (see note below)
+```
+
+> **Note on `binforge/`:** `git ls-files binforge` returns nothing — the
+> directory is not tracked by git. Only local, git-ignored `.env*` files remain
+> on disk. It is the earlier prototype of this service; the maintained code now
+> lives entirely under `services/data-simulator/`. Do not treat `binforge/` as
+> part of the service. *(TODO: confirm with team whether `binforge/` should be
+> deleted from working copies.)*
+
+---
+
+## The service: `services/data-simulator/`
+
+```text
+services/data-simulator/
+├── Dockerfile                    # Multi-stage build: base → test → runtime
+├── .dockerignore                 # Build-context excludes (keeps .env.docker in)
+├── .env.docker                   # Runtime env for the Docker stack (git-IGNORED; local only)
+├── .env.local.example            # Template env for running natively (git-tracked)
+├── pytest.ini                    # pytest config (testpaths, pythonpath)
+├── requirements.txt              # Runtime dependencies
+├── requirements-dev.txt          # Dev/test dependencies (includes -r requirements.txt)
+├── scripts/
+│   ├── run_local.sh              # Start infra in Docker + run simulator natively (Linux/macOS)
+│   └── run_local.ps1             # Same, for Windows PowerShell
+├── src/                          # Application source (no __init__.py — flat module imports)
+│   ├── main.py                   # Async entrypoint: orchestrates startup/shutdown
+│   ├── config.py                 # Pydantic Settings; env-var loading + DATABASE_URL
+│   ├── database.py               # Async SQLAlchemy engine, session factory, SmartBin ORM model
+│   ├── create_tables.py          # One-off: creates tables via Base.metadata.create_all
+│   ├── seed.py                   # CLI: seed mock bins into the DB (--count / --clear)
+│   ├── kafka_producer.py         # AIOKafkaProducer wrapper (singleton `kafka_client`)
+│   ├── logging_config.py         # Colored console + rotating file logging; SIGUSR1 toggle
+│   ├── models/
+│   │   └── bin.py                # `Bin` domain model (in-memory telemetry state)
+│   └── simulator/
+│       ├── __init__.py           # (empty)
+│       ├── bin_simulator.py      # `BinSimulator`: per-bin async telemetry loop
+│       └── simulation_manager.py # `SimulationManager`: registry of all BinSimulators
+└── tests/                        # pytest suite (mirrors src/ layout)
+    ├── conftest.py               # Dummy env vars + docstring-in-verbose-output hooks
+    ├── test_config.py            # Settings / DATABASE_URL
+    ├── test_database.py          # SmartBin ORM mapping
+    ├── test_create_tables.py     # create_tables / main
+    ├── test_seed.py              # seed_db behavior + safety guard
+    ├── test_kafka_producer.py    # KafkaClient start/stop/send + retry logic
+    ├── test_logging_config.py    # setup_logging + SIGUSR1 toggle
+    ├── test_main.py              # main() startup/shutdown orchestration
+    ├── models/
+    │   └── test_bin.py           # Bin model
+    └── simulator/
+        ├── test_bin_simulator.py       # BinSimulator lifecycle + _simulate
+        └── test_simulation_manager.py  # SimulationManager registry ops
+```
+
+### Module responsibilities (one line each)
+
+| Module | Responsibility |
+| --- | --- |
+| `src/main.py` | Async entrypoint. Starts Kafka client + `SimulationManager`, installs SIGINT/SIGTERM handlers, awaits a stop event, then tears everything down with timeouts. |
+| `src/config.py` | Defines the `Settings` pydantic model, reads env vars, exposes `get_settings()` (`lru_cache`) and a computed `DATABASE_URL`. |
+| `src/database.py` | Declares the async engine, `AsyncSessionLocal` session factory, and the `SmartBin` SQLAlchemy ORM model (persisted bin metadata). |
+| `src/create_tables.py` | Developer helper that creates all tables from ORM metadata. No migrations. |
+| `src/seed.py` | Standalone CLI that inserts mock `SmartBin` rows using `Faker`. Caps at 500 rows. |
+| `src/kafka_producer.py` | `KafkaClient` wrapping `AIOKafkaProducer` with connection retries; module-level singleton `kafka_client`. |
+| `src/logging_config.py` | Configures root logging (color console + rotating file), suppresses noisy libs, registers a SIGUSR1 handler to toggle DEBUG/INFO at runtime. |
+| `src/models/bin.py` | `Bin` — the in-memory domain object holding a bin's live fill/battery state and building the telemetry payload. Infrastructure-agnostic. |
+| `src/simulator/bin_simulator.py` | `BinSimulator` — owns one `Bin`, runs the periodic simulate-and-publish asyncio task. |
+| `src/simulator/simulation_manager.py` | `SimulationManager` — in-memory `dict[bin_id, BinSimulator]`; loads ACTIVE bins from the DB and manages simulator lifecycles. |
+
+---
+
+## Supporting directories
+
+| Path | Purpose |
+| --- | --- |
+| `.github/workflows/` | CI: `pr-controller.yml` (governance router), `feature-policy.yml` (reusable scope check), `pr-pytest.yml` (test runner). See [ci-cd.md](ci-cd.md). |
+| `docs/features/` | Feature docs. `docs/features/README.md` is the docs index; `docs/features/data-simulator/` is this service's docs. |
+| `scripts/` (in service) | Local dev launchers that bring up infra in Docker and run the simulator on the host. |
+
+---
+
+## Related documents
+
+- [architecture.md](architecture.md) — how these modules interact at runtime.
+- [configuration.md](configuration.md) — the env vars each module reads.
+- [contributing.md](contributing.md) — conventions and where to add new code.

--- a/docs/features/data-simulator/simulation-engine.md
+++ b/docs/features/data-simulator/simulation-engine.md
@@ -1,0 +1,163 @@
+# Simulation Engine
+
+The simulation engine is the core loop that turns static bin metadata into a
+continuous stream of realistic-looking telemetry. It is built from three
+collaborating pieces:
+
+- `Bin` (`src/models/bin.py`) — the in-memory state of one bin.
+- `BinSimulator` (`src/simulator/bin_simulator.py`) — the per-bin async loop.
+- `SimulationManager` (`src/simulator/simulation_manager.py`) — the registry
+  that owns all simulators.
+
+Randomness is provided by `Faker` (`from faker import Faker; fake = Faker()`).
+
+---
+
+## Inputs and outputs
+
+**Input:** each `ACTIVE` row in the `smart_bins` table — `bin_id`, `capacity`,
+`latitude`, `longitude` (`SimulationManager.initialize`, loaded once at
+startup).
+
+**Output:** one JSON telemetry message per bin per `SIMULATION_INTERVAL`
+seconds, published to Kafka keyed by `bin_id`. The payload shape comes from
+`Bin.to_payload()` (`src/models/bin.py:75-91`):
+
+```json
+{
+  "bin_id": "BIN-1A2B3C4D-X",
+  "capacity": 100.0,
+  "current_fill_level": 42.37,
+  "battery_level": 98.61,
+  "latitude": 40.1234,
+  "longitude": -73.9876,
+  "timestamp": "2026-08-02T12:34:56.789012+00:00"
+}
+```
+
+`current_fill_level` and `battery_level` are rounded to 2 decimals; `timestamp`
+is UTC ISO-8601 (`datetime.now(timezone.utc).isoformat()`).
+
+---
+
+## The per-bin loop (`BinSimulator._run`)
+
+`src/simulator/bin_simulator.py:118-147`:
+
+```text
+while self._running:
+    self._simulate()                                  # mutate in-memory state
+    await kafka_client.send_telemetry(                # publish current state
+        self.bin.bin_id, self.bin.to_payload()
+    )
+    await asyncio.sleep(settings.SIMULATION_INTERVAL) # wait one tick
+```
+
+Each bin runs this loop inside its own `asyncio.Task`, created in `start()`
+(`self._task = asyncio.create_task(self._run())`, line 74). Because all tasks
+share one event loop, thousands of bins are multiplexed cooperatively — while
+one bin is `await`-ing Kafka or `asyncio.sleep`, others make progress. See
+[decisions/001-asyncio.md](decisions/001-asyncio.md).
+
+### Lifecycle
+
+| Method | Behavior |
+| --- | --- |
+| `start()` | Idempotent: if already running, logs a warning and returns; otherwise sets `_running = True` and schedules `_run()` as a task (`bin_simulator.py:60-79`). |
+| `stop()` | Sets `_running = False`, cancels the task if not done, and awaits it — swallowing the expected `asyncio.CancelledError`. No-op with a warning if already stopped (`bin_simulator.py:81-116`). |
+
+---
+
+## The telemetry model (`BinSimulator._simulate`)
+
+`src/simulator/bin_simulator.py:149-190`. Each tick updates two quantities:
+
+**Fill level** — with a 5% chance the bin is "emptied" (collection event),
+resetting `current_fill_level` to `0`; otherwise it increases by a random
+amount and is clamped to `capacity`:
+
+```python
+if fake.boolean(chance_of_getting_true=5):
+    self.bin.current_fill_level = 0
+else:
+    increase = fake.pyfloat(min_value=0.5, max_value=5.0)
+    self.bin.current_fill_level = min(
+        self.bin.capacity,
+        self.bin.current_fill_level + increase,
+    )
+```
+
+**Battery level** — monotonically drains by a small random amount each tick,
+clamped at a floor of `0`:
+
+```python
+self.bin.battery_level = max(
+    0,
+    self.bin.battery_level - fake.pyfloat(min_value=0.01, max_value=0.1),
+)
+```
+
+Summary of the model:
+
+| Quantity | Start | Per-tick change | Bound |
+| --- | --- | --- | --- |
+| `current_fill_level` | `0.0` | +0.5..5.0, or reset to 0 (5% chance) | clamped to `[0, capacity]` |
+| `battery_level` | `100.0` | −0.01..0.1 | clamped at `0` floor |
+
+These behaviors are pinned by tests: normal increase/drain, empty event,
+capacity clamp, and battery floor (`tests/simulator/test_bin_simulator.py:61-157`).
+
+> Note: because `battery_level` only drains and is never recharged, a
+> long-running bin will trend toward 0. There is no low-battery alert or
+> replacement logic in the current code.
+
+---
+
+## The registry (`SimulationManager`)
+
+`src/simulator/simulation_manager.py`. Holds `_simulators: dict[str,
+BinSimulator]` and manages their lifecycles.
+
+| Method | Sync/async | Behavior |
+| --- | --- | --- |
+| `initialize()` | async | Opens a session, `select(SmartBin).where(status == "ACTIVE")`, builds a `Bin` + `BinSimulator` per row, starts each, registers it (`:34-65`). |
+| `add_bin(bin)` | sync | Creates + starts a simulator for a new bin; warns if already present (`:68-91`). |
+| `remove_bin(bin_id)` | async | Pops and `await`s `stop()` on the simulator; warns if absent (`:93-115`). |
+| `update_bin(bin_id, lat, lon)` | sync | Delegates to `Bin.update_location`; warns if absent (`:117-153`). |
+| `stop()` | async | Stops every simulator and clears the registry (`:155-169`). |
+| `get_simulator` / `exists` / `simulators` | sync | Read-only registry accessors (`:171-208`). |
+
+> **Only `initialize()` is currently invoked at runtime** (from `main.py`). The
+> `add_bin` / `update_bin` / `remove_bin` methods are implemented and unit-
+> tested but not wired to any external trigger. The source marks this as future
+> work: "Add, update, delete - need to be implemented with Fast API in future"
+> (`simulation_manager.py:67`).
+
+---
+
+## Extension points
+
+If you extend the engine, these are the natural seams (all verified in code):
+
+1. **Telemetry model** — change the math in `BinSimulator._simulate()` (add
+   sensors, seasonal patterns, correlated failures). Keep it synchronous and
+   side-effect-free except for mutating `self.bin`.
+2. **Payload shape** — extend `Bin.to_payload()` and add the corresponding
+   in-memory attributes in `Bin.__init__`. Downstream consumers depend on this
+   schema — see [kafka.md](kafka.md).
+3. **Tick interval** — governed by `SIMULATION_INTERVAL` (config), read fresh
+   from settings on each loop iteration.
+4. **Dynamic fleet management** — implement the trigger (e.g. the mentioned
+   FastAPI layer) that calls `SimulationManager.add_bin` / `update_bin` /
+   `remove_bin`, and add periodic DB reconciliation to pick up new rows.
+5. **Sink** — telemetry publishing is isolated behind
+   `kafka_client.send_telemetry(...)`; swap the sink there without touching the
+   loop.
+
+---
+
+## Related documents
+
+- [architecture.md](architecture.md) — how the engine fits the whole process.
+- [kafka.md](kafka.md) — the delivery path and message schema.
+- [database.md](database.md) — the source of bin metadata.

--- a/docs/features/data-simulator/testing.md
+++ b/docs/features/data-simulator/testing.md
@@ -1,0 +1,164 @@
+# Testing
+
+The service ships a `pytest` suite covering config, database model, table
+creation, seeding, the Kafka client, logging, the entrypoint, and the
+simulation engine. Tests are **fully mocked** — they require no running
+Postgres or Kafka.
+
+---
+
+## Layout
+
+`tests/` mirrors `src/`:
+
+```text
+tests/
+├── conftest.py                       # dummy env vars + verbose-output docstring hooks
+├── test_config.py                    # Settings / DATABASE_URL / validation
+├── test_database.py                  # SmartBin ORM mapping (no DB — SQLAlchemy inspection)
+├── test_create_tables.py             # create_tables() / main() with mocked engine
+├── test_seed.py                      # seed_db(): create/clear/guard/dispose
+├── test_kafka_producer.py            # KafkaClient: start/retry/send/stop
+├── test_logging_config.py            # setup_logging + SIGUSR1 toggle
+├── test_main.py                      # main() startup/shutdown orchestration
+├── models/
+│   └── test_bin.py                   # Bin model: init / update_location / to_payload
+└── simulator/
+    ├── test_bin_simulator.py         # BinSimulator lifecycle + _simulate math
+    └── test_simulation_manager.py    # SimulationManager registry operations
+```
+
+---
+
+## Configuration — `pytest.ini`
+
+```ini
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+pythonpath = . src
+```
+
+`pythonpath = . src` puts both the service root and `src/` on `sys.path`, which
+is why tests can import both `from src.models.bin import Bin` **and**
+`from database import SmartBin` (the same style `src/` modules use internally).
+
+> **Import-identity caveat (documented in the code):** because `src/` has no
+> `__init__.py`, `database.SmartBin` and `src.database.SmartBin` are two
+> distinct class objects. `tests/test_seed.py:6-10` deliberately imports
+> `SmartBin` the same way `seed.py` does (`from database import ...`) so
+> `isinstance` / call-arg assertions match. Keep this in mind when adding tests
+> that assert on classes crossing that boundary.
+
+### `conftest.py`
+
+Two responsibilities (`tests/conftest.py`):
+
+1. **Dummy env vars** set at import time so `Settings()` constructs without a
+   real environment (`POSTGRES_*`, `KAFKA_*` — see
+   [configuration.md](configuration.md)).
+2. **Verbose docstring reporting hooks** — `pytest_runtest_makereport` +
+   `pytest_report_teststatus` append each test's first docstring line to the
+   `-v` outcome (e.g. `PASSED  Test the successful startup...`). This is why the
+   tests carry descriptive docstrings.
+
+---
+
+## Async testing
+
+Async tests use `pytest-asyncio` via the `@pytest.mark.asyncio` decorator
+(applied per-test, e.g. `test_kafka_producer.py`, `test_main.py`,
+`test_simulation_manager.py`). External I/O is replaced with
+`unittest.mock` (`AsyncMock` / `MagicMock` / `patch`):
+
+- Kafka: `AIOKafkaProducer` is patched; retry/sleep behavior is asserted by
+  patching `src.kafka_producer.asyncio.sleep`.
+- Database: `AsyncSessionLocal`, `create_async_engine`, and
+  `async_sessionmaker` are patched — **no real Postgres** is contacted.
+- Signals/loop: `test_main.py` neutralizes real
+  `loop.add_signal_handler` and makes `stop_event.wait()` resolve immediately so
+  `main()` runs start→shutdown without hanging.
+
+---
+
+## Running the tests
+
+### Locally (native)
+
+From `services/data-simulator/`:
+
+```bash
+pip install -r requirements-dev.txt
+PYTHONPATH=src pytest -v
+```
+
+`requirements-dev.txt` pulls in runtime deps (`-r requirements.txt`) plus
+`pytest`, `pytest-asyncio`, `pytest-cov`, `ruff`, `mypy`, `pre-commit`.
+
+### Inside the running container (matches the root README)
+
+```bash
+docker exec -it data_simulator pip install -r requirements-dev.txt
+docker exec -it data_simulator pytest -v
+```
+
+This runs the suite without rebuilding the image.
+
+### At image-build time
+
+The Dockerfile's `test` stage runs `pytest` during
+`docker build --target test services/data-simulator` — a failing test fails the
+build. See [deployment.md](deployment.md).
+
+### As CI runs it (authoritative)
+
+`.github/workflows/pr-pytest.yml` runs, from `services/data-simulator`:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+PYTHONPATH=src pytest -v          # env: PYTHONPATH=src
+```
+
+on Python 3.12. See [ci-cd.md](ci-cd.md).
+
+---
+
+## Coverage
+
+`pytest-cov` is installed and a local `.coverage` file exists, but **coverage is
+not enforced**: neither `pytest.ini`, the CI command, nor the Dockerfile passes
+`--cov` or a threshold. To generate a report on demand:
+
+```bash
+PYTHONPATH=src pytest --cov=src --cov-report=term-missing
+```
+
+*(TODO: confirm with team whether a coverage gate is desired — it is listed as a
+future enhancement in `pr-pytest-doc.md`.)*
+
+---
+
+## What is and isn't covered
+
+**Covered (unit):** `Settings`/`DATABASE_URL`, `SmartBin` mapping, `create_tables`,
+`seed_db` (including the 500-bin guard and finally-dispose), `KafkaClient`
+(success, 10× retry-then-fail, retry-then-success, send success/failure/not-
+started, stop), `setup_logging` (idempotence, levels, SIGUSR1 registration),
+`_toggle_log_level`, `main()` orchestration order, `Bin`, `BinSimulator`
+(lifecycle + fill/battery/clamp math), `SimulationManager` (initialize, add,
+remove, update, stop, accessors).
+
+**Not covered:** any real Postgres or Kafka integration (everything is mocked);
+end-to-end "seed → run → observe on topic" flow; the hybrid `run_local.*`
+scripts. There is **no integration-test suite** in the repo. *(TODO: confirm
+with team whether integration tests are planned.)*
+
+---
+
+## Related documents
+
+- [ci-cd.md](ci-cd.md) — how CI invokes these tests.
+- [contributing.md](contributing.md) — conventions for adding tests.

--- a/docs/features/data-simulator/troubleshooting.md
+++ b/docs/features/data-simulator/troubleshooting.md
@@ -1,0 +1,210 @@
+# Troubleshooting
+
+Common failure modes, keyed to real error handling and log messages in the
+source. Each entry: **symptom → likely cause → fix**.
+
+---
+
+## `docker compose up` fails: env file not found
+
+**Symptom:** Compose errors immediately with something like
+`env file .../services/data-simulator/.env.docker not found`.
+
+**Cause:** `docker-compose.yml` reads `./services/data-simulator/.env.docker`,
+but that file is **git-ignored** and absent on a fresh clone. The root
+`README.md` tells you to create `.env.docker.local` instead — a name Compose
+never references. (See [configuration.md](configuration.md) for the full
+discrepancy.)
+
+**Fix:**
+
+```bash
+cp services/data-simulator/.env.local.example services/data-simulator/.env.docker
+# then set, in that file:
+#   POSTGRES_HOST=postgres
+#   KAFKA_BOOTSTRAP_SERVERS=kafka:29092
+```
+
+---
+
+## Simulator logs `Started 0 simulator(s).` and no telemetry appears
+
+**Symptom:** startup succeeds but the Kafka topic stays empty; log shows
+`Started 0 simulator(s).`
+
+**Cause:** the `smart_bins` table has no `ACTIVE` rows.
+`SimulationManager.initialize()` only loads bins `where status == "ACTIVE"`
+(`simulation_manager.py:43-45`), so with an empty/unsimulated DB there is
+nothing to emit.
+
+**Fix:** seed data, then restart to reload:
+
+```bash
+docker compose run --rm data_simulator python src/seed.py --count 50
+docker compose restart data_simulator
+```
+
+Remember the simulator loads bins **once at startup** — seeding without a
+restart does nothing.
+
+---
+
+## Seeded bins, but still no telemetry
+
+**Symptom:** `smart_bins` has rows (confirmed via `psql`), but the topic is
+still empty.
+
+**Cause:** the simulator was already running when you seeded; it never re-reads
+the DB.
+
+**Fix:** `docker compose restart data_simulator`. Confirm the log now says
+`Started N simulator(s).` with N > 0. (See
+[simulation-engine.md](simulation-engine.md) on the one-shot load.)
+
+---
+
+## Repeated `Kafka not ready yet (...), retrying... (i/10)`
+
+**Symptom:** startup loops on this warning
+(`kafka_producer.py:33-35`).
+
+**Cause:** the broker is not reachable at `KAFKA_BOOTSTRAP_SERVERS`. Normal for
+a few seconds at boot (the simulator has **no** `depends_on: kafka`), but a
+problem if it persists. Usual reasons:
+
+- Wrong address for the context: containers must use `kafka:29092`; host
+  processes must use `localhost:9092` (see [kafka.md](kafka.md)).
+- Kafka container unhealthy/not started.
+
+**Fix:** verify the value matches where you're running (`.env.docker` =
+`kafka:29092`, `.env.local` = `localhost:9092`); check `docker ps` /
+`docker logs smartbin_kafka`.
+
+---
+
+## `Could not connect to Kafka ... after multiple retries` then the process exits
+
+**Symptom:** after 10 attempts (~30s) the producer raises and `main()` never
+starts the manager; the container exits.
+
+**Cause:** Kafka was unreachable for the full retry window
+(`kafka_producer.py:42-44`).
+
+**Fix:** ensure Kafka is up and the bootstrap address is correct, then restart
+`data_simulator`. Increase the retry budget only if your broker is legitimately
+slow to start (edit the `retries`/sleep in `KafkaClient.start`).
+
+---
+
+## `Kafka producer is not started; dropping telemetry for <bin>`
+
+**Symptom:** this error is logged and payloads are lost
+(`kafka_producer.py:52-56`).
+
+**Cause:** `send_telemetry` was called before `kafka_client.start()` completed.
+In normal operation `main()` starts the client before the manager, so seeing
+this suggests a startup-order regression or a partially failed start.
+
+**Fix:** check that `Kafka Client Started Successfully` appears **before**
+`Started N simulator(s).` in the logs; if not, investigate the start sequence in
+`src/main.py`.
+
+---
+
+## `Failed to send telemetry for <bin>: <error>`
+
+**Symptom:** intermittent per-message errors; telemetry has gaps
+(`kafka_producer.py:61-62`).
+
+**Cause:** a `send_and_wait` failed (broker hiccup, timeout). Delivery is
+best-effort — the failed message is **dropped, not retried**
+(see [kafka.md](kafka.md#delivery-guarantees-as-actually-configured)).
+
+**Fix:** usually self-heals on the next tick (a fresh full snapshot is sent). If
+frequent, investigate broker health; for stronger guarantees add producer
+`acks="all"` + `enable_idempotence=True` + retries.
+
+---
+
+## DB connection errors / `An error occurred while seeding: ...`
+
+**Symptom:** the simulator can't reach Postgres at startup, or `seed.py` prints
+`An error occurred while seeding: <error>` (`seed.py:45-46`).
+
+**Cause:** wrong `POSTGRES_*` values or Postgres not ready/healthy. Note the
+**host port is 5433** (`docker-compose.yml`), while the containers and the
+`.env.local` template use **5432**.
+
+- From another container: host `postgres`, port `5432`.
+- From the host machine (e.g. a psql client, or the hybrid `run_local` mode
+  connecting to the published port): `localhost:5433`.
+
+**Fix:** align `POSTGRES_HOST`/`POSTGRES_PORT` with where the client runs. Note
+`data_simulator` waits for Postgres health (`condition: service_healthy`), so
+startup DB failures usually indicate bad credentials/DB name rather than
+readiness.
+
+> **Known port mismatch:** `scripts/run_local.sh` sources `.env.local`, whose
+> template still has `POSTGRES_PORT=5432`, but Docker publishes Postgres on the
+> host as **5433**. If you run the simulator natively against the Dockerized
+> Postgres, set `POSTGRES_PORT=5433` in your `.env.local`. *(TODO: confirm with
+> team and align the template.)*
+
+---
+
+## Seeding refuses more than 500 bins
+
+**Symptom:** `Error: For safety, you cannot seed more than 500 bins at a time.`
+
+**Cause:** intentional guard in `seed.py:16-18`.
+
+**Fix:** run `seed.py` multiple times, or raise the guard if you genuinely need
+more (and see [operations.md](operations.md#scaling) on scale limits).
+
+---
+
+## Table does not exist when seeding/running
+
+**Symptom:** a "relation smart_bins does not exist" style error.
+
+**Cause:** nothing in the startup path or `seed.py` creates the schema — only
+`create_tables.py` does, and there are no Alembic migrations (see
+[database.md](database.md)).
+
+**Fix:**
+
+```bash
+docker compose run --rm data_simulator python src/create_tables.py
+```
+
+---
+
+## Duplicate telemetry for every bin
+
+**Symptom:** each `bin_id` appears multiple times per interval on the topic.
+
+**Cause:** more than one `data_simulator` instance is running; each loads the
+same `ACTIVE` bins. Horizontal scaling is not supported as-is
+(see [operations.md](operations.md#scaling)).
+
+**Fix:** run a single simulator instance.
+
+---
+
+## Tests fail to import (`ModuleNotFoundError`)
+
+**Symptom:** `pytest` can't import `src...` or `database`/`config`.
+
+**Cause:** missing path setup. Tests rely on `pythonpath = . src` from
+`pytest.ini`; CI additionally sets `PYTHONPATH=src`.
+
+**Fix:** run from `services/data-simulator/` (so `pytest.ini` is picked up), or
+`PYTHONPATH=src pytest -v`. See [testing.md](testing.md).
+
+---
+
+## Related documents
+
+- [operations.md](operations.md) — monitoring and the log signals table.
+- [configuration.md](configuration.md) — env vars and the env-file discrepancy.
+- [kafka.md](kafka.md) / [database.md](database.md) — subsystem specifics.


### PR DESCRIPTION
## Summary

Adds the complete Data Simulator documentation set under
`docs/features/data-simulator/` (13 topic docs + 4 ADRs) and corrects the root
`README.md` to match the actual code. Every doc was written from verified
source (code, configs, CI YAML, compose/Dockerfile) with file-path citations.

## Files
- `docs/features/data-simulator/`: architecture, deployment, configuration,
  simulation-engine, database, kafka, testing, ci-cd, troubleshooting,
  operations, project-structure, contributing
- `docs/features/data-simulator/decisions/`: 001-asyncio, 002-postgresql,
  003-kafka, 004-simulation-manager (ADRs; reasoning marked "inferred from
  codebase")
- `README.md` (root): corrected + linked into the docs

## Discrepancies flagged (code trusted over prior docs)
1. **Env-file name:** Compose reads `.env.docker` (git-ignored), but the old
   README said create `.env.docker.local` — a name Compose never uses. README
   corrected; detailed in `configuration.md` / `deployment.md` / `troubleshooting.md`.
2. **Missing schema step:** the old quickstart seeded without creating tables.
   Added `create_tables.py` step (there are no Alembic migrations despite the
   dependency).
3. **`NUMBER_OF_BINS` is dead config** — defined/tested but read by no runtime code.
4. **No linter in CI** — README claimed `act`/CI "runs Ruff"; no workflow runs
   ruff/black/mypy. Corrected.

## Needs human review
Items marked `TODO: confirm with team` in the docs (canonical env-file name,
Alembic intent, topic auto-create, horizontal-scale plans, review/branch-
protection settings). See the job report for the full list.

## Note on CI
This branch is not named `feature/<service>/docs`, and it also edits root
`README.md`, so the repo's feature-policy governance check would not pass as-is
(root README is outside `docs/features/<service>/**`). Re-target/rename per the
governance policy before merging if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)