### PR TITLE
Add the Spark processing layer

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,11 +6,19 @@ behavior.
 
 ## Current implementation
 
-- `services/data-simulator/` is the only implemented service. It is a Python
-  3.12 AsyncIO application that loads static bin metadata from PostgreSQL and
-  publishes simulated telemetry to Kafka.
-- `docker-compose.yml` runs PostgreSQL 15, Kafka in single-node KRaft mode, and
-  the simulator.
+- `services/data-simulator/` is a Python 3.12 AsyncIO application that loads
+  static bin metadata from PostgreSQL and publishes simulated telemetry to
+  Kafka. A share of bins misbehave on purpose so the detectors downstream have
+  something to detect.
+- `services/stream-processor/` is a Python **3.11** PySpark application that
+  reads that topic and writes alerts, per-bin state and zone aggregates to
+  PostgreSQL, plus a Parquet history. 3.11 rather than 3.12 because PySpark 3.5
+  does not support 3.12.
+- `contracts/telemetry-v1.json` is the payload agreement between them. Both
+  sides assert against it, so a renamed field fails a test instead of silently
+  reading as nulls downstream.
+- `docker-compose.yml` runs PostgreSQL 15, Kafka in single-node KRaft mode, a
+  one-shot topic creator, the simulator and the stream processor.
 - Root `binforge/` content is ignored local scratch. The tracked implementation
   lives under `services/data-simulator/`.
 
@@ -21,12 +29,17 @@ Full Docker:
 ```bash
 test -f services/data-simulator/.env.docker || \
   cp services/data-simulator/.env.local.example services/data-simulator/.env.docker
-docker compose up -d postgres kafka
-docker compose build data_simulator
+docker compose up -d postgres kafka kafka_init
+docker compose build data_simulator stream_processor
 docker compose run --rm data_simulator alembic upgrade head
-docker compose run --rm data_simulator python src/seed.py --count 50
-docker compose up -d --force-recreate data_simulator
+docker compose run --rm data_simulator python src/seed.py --count 200
+docker compose up -d --force-recreate data_simulator stream_processor
 ```
+
+`alembic upgrade head` prints nothing — `alembic.ini` carries no logging
+sections. A successful seed is the confirmation that it ran.
+
+To verify the whole pipeline rather than just start it, use `/verify-pipeline`.
 
 Hybrid local:
 
@@ -43,8 +56,8 @@ PYTHONPATH=. python src/seed.py --count 50
 Tests:
 
 ```bash
-cd services/data-simulator
-pytest -q
+cd services/data-simulator   && pytest -q     # Python 3.12
+cd services/stream-processor && pytest -q     # Python 3.11
 ```
 
 ## Skills
@@ -55,7 +68,8 @@ pytest -q
 | `breadcrumb-creator` | Add or repair a flow breadcrumb. |
 | `simulation-engine` | Bin state, simulator tasks, manager, and telemetry. |
 | `database` | SQLAlchemy, Alembic, `smart_bins`, and seeding. |
-| `kafka` | Producer lifecycle, payloads, and broker configuration. |
+| `kafka` | Producer lifecycle, payloads, topics, and broker configuration. |
+| `spark` | Structured Streaming, the alert rules, checkpoints, and rollups. |
 | `config` | Settings, environment variables, and database URL construction. |
 | `testing` | Pytest fixtures, mocks, and commands. |
 | `ci-cd` | GitHub Actions and branch policy. |

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -39,6 +39,11 @@ docker compose up -d --force-recreate data_simulator stream_processor
 `alembic upgrade head` names each revision it applies; only the two
 `Context impl` lines means the database was already at head.
 
+The order matters. Starting the simulator before migrating reports
+`The 'smart_bins' table does not exist.` with the commands to run and exits 1;
+before seeding it warns `No ACTIVE bins found`. Once running it is silent,
+because per-tick telemetry is DEBUG.
+
 The Spark UI is at <http://localhost:4040> (batch job: 4041). Its Structured
 Streaming tab is the fastest way to see whether the queries are consuming.
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -36,8 +36,11 @@ docker compose run --rm data_simulator python src/seed.py --count 200
 docker compose up -d --force-recreate data_simulator stream_processor
 ```
 
-`alembic upgrade head` prints nothing — `alembic.ini` carries no logging
-sections. A successful seed is the confirmation that it ran.
+`alembic upgrade head` names each revision it applies; only the two
+`Context impl` lines means the database was already at head.
+
+The Spark UI is at <http://localhost:4040> (batch job: 4041). Its Structured
+Streaming tab is the fastest way to see whether the queries are consuming.
 
 To verify the whole pipeline rather than just start it, use `/verify-pipeline`.
 

--- a/.claude/breadcrumbs/_INDEX.md
+++ b/.claude/breadcrumbs/_INDEX.md
@@ -16,7 +16,7 @@ line numbers can move.
 | PR governance and tests | [`ci-pr-governance/`](ci-pr-governance/FLOW.md) | Detect branch type, enforce feature scope, and run pytest. |
 | Fault injection | [`fault-injection/`](fault-injection/FLOW.md) | Make bins misbehave on purpose so every detector has something to detect. |
 | Stream processing | [`stream-processing/`](stream-processing/FLOW.md) | Kafka to Spark: clean, deduplicate, dead-letter, aggregate, and write. |
-| Alert detection | [`alert-detection/`](alert-detection/FLOW.md) | The per-bin stateful operator and its eleven alert types. |
+| Alert detection | [`alert-detection/`](alert-detection/FLOW.md) | The per-bin stateful operator and its twelve alert types. |
 
 ## Symptom routing
 

--- a/.claude/breadcrumbs/_INDEX.md
+++ b/.claude/breadcrumbs/_INDEX.md
@@ -14,6 +14,9 @@ line numbers can move.
 | Schema migrations | [`schema-migrations/`](schema-migrations/FLOW.md) | Alembic revision discovery, upgrade, downgrade, and legacy adoption. |
 | Database seeding | [`database-seeding/`](database-seeding/FLOW.md) | Generate Hyderabad-zone bins and commit them to `smart_bins`. |
 | PR governance and tests | [`ci-pr-governance/`](ci-pr-governance/FLOW.md) | Detect branch type, enforce feature scope, and run pytest. |
+| Fault injection | [`fault-injection/`](fault-injection/FLOW.md) | Make bins misbehave on purpose so every detector has something to detect. |
+| Stream processing | [`stream-processing/`](stream-processing/FLOW.md) | Kafka to Spark: clean, deduplicate, dead-letter, aggregate, and write. |
+| Alert detection | [`alert-detection/`](alert-detection/FLOW.md) | The per-bin stateful operator and its eleven alert types. |
 
 ## Symptom routing
 
@@ -26,3 +29,7 @@ line numbers can move.
 | Unknown Alembic revision or missing table | [`schema-migrations/DEBUG.md`](schema-migrations/DEBUG.md) |
 | Seeding failure or unexpected zones | [`database-seeding/DEBUG.md`](database-seeding/DEBUG.md) |
 | Branch policy or CI failure | [`ci-pr-governance/DEBUG.md`](ci-pr-governance/DEBUG.md) |
+| No faults injected, or a detector never fires | [`fault-injection/DEBUG.md`](fault-injection/DEBUG.md) |
+| Empty Spark output tables, or checkpoint problems | [`stream-processing/DEBUG.md`](stream-processing/DEBUG.md) |
+| An alert fires too often, never, or wrongly | [`alert-detection/DEBUG.md`](alert-detection/DEBUG.md) |
+| Bins missing from `bin_state_latest` | [`stream-processing/DEBUG.md`](stream-processing/DEBUG.md) |

--- a/.claude/breadcrumbs/alert-detection/DEBUG.md
+++ b/.claude/breadcrumbs/alert-detection/DEBUG.md
@@ -7,8 +7,12 @@
 | One alert type never fires | Its condition may not be reachable. Check the matching fault mode is being injected — see [`fault-injection`](../fault-injection/DEBUG.md). |
 | `FIRE_RISK` never fires | Needs hot **and** nearly full together. A bin pinned hot while empty satisfies one half forever and the other never. |
 | `OFFLINE` never fires | Watermark, not the rule — see [`stream-processing/DEBUG.md`](../stream-processing/DEBUG.md). Also: a bin that never published at all has no state and no timer. |
-| `SLA_BREACH` never fires | Every healthy bin is collected well inside the allowance. Only an `UNCOLLECTED` bin breaches. |
+| `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` never fires | Every healthy bin is collected well inside the allowance. Only an `UNCOLLECTED` bin breaches. |
 | An alert fires on every reading | Its fire-once flag is not being set, or is cleared each time by the reading itself. |
+| `CRITICAL_FILL` or `OVERFLOW` fires repeatedly for one bin | Their flags clear on a **collection only**. If they are re-firing, something else is clearing them - a dip back under the threshold must not. |
+| `SENSOR_STUCK` never fires | Readings at 100% are not counted, by design. A `FROZEN` bin frozen at empty **is** counted - if those are silent too, check `saturated` in `evaluate_reading` has not grown a lower bound. |
+| `SENSOR_STUCK` fires for healthy full bins | The 100% exclusion is gone. Fill is clamped at capacity, so every bin awaiting collection repeats the same reading. |
+| A second broken sensor raises no alert | `reported_faults` compares fault *names*. A boolean there hides every failure after the first. |
 | The same alert repeats after a restart | The checkpoint was deleted, so every bin looks new. |
 | `COLLECTED` where no collection happened | Events processed out of order. `track_bin` sorts by `event_time`; check that sort survived an edit. |
 | Alerts duplicated in `bin_alerts` | The `(bin_id, alert_type, fired_at)` conflict key is missing. Retried micro-batches rely on it. |
@@ -22,9 +26,16 @@ docker exec smartbin_postgres psql -U postgres -d smart_city -c \
      FROM bin_alerts GROUP BY 1,2 ORDER BY 3 DESC;"
 ```
 
-With fault injection on, all eleven types should appear given enough time.
-`FIRE_RISK` and `OFFLINE` will have the smallest counts — only a few bins carry
-those faults.
+With fault injection on, all twelve types should appear given enough time.
+`FIRE_RISK`, `OFFLINE` and `SENSOR_STUCK` will have the smallest counts — only a
+few bins carry those faults.
+
+On the default profile the SLA clocks are two hours and thirty minutes, so
+`SLA_BREACH_*` and `LOW_BATTERY` need the demo profile in `.env.local.example`
+to appear inside a session. Both halves of that profile matter: the simulator's
+pacing **and** the processor's clocks. Speeding up only the simulator is the
+easy mistake — the SLA allowance is the processor's, so a bin still takes two
+hours to breach no matter how fast it fills.
 
 ## Inspecting one bin
 

--- a/.claude/breadcrumbs/alert-detection/DEBUG.md
+++ b/.claude/breadcrumbs/alert-detection/DEBUG.md
@@ -1,0 +1,64 @@
+# Alert Detection — Debug Guide
+
+## Symptom routing
+
+| Symptom | Check |
+|---|---|
+| One alert type never fires | Its condition may not be reachable. Check the matching fault mode is being injected — see [`fault-injection`](../fault-injection/DEBUG.md). |
+| `FIRE_RISK` never fires | Needs hot **and** nearly full together. A bin pinned hot while empty satisfies one half forever and the other never. |
+| `OFFLINE` never fires | Watermark, not the rule — see [`stream-processing/DEBUG.md`](../stream-processing/DEBUG.md). Also: a bin that never published at all has no state and no timer. |
+| `SLA_BREACH` never fires | Every healthy bin is collected well inside the allowance. Only an `UNCOLLECTED` bin breaches. |
+| An alert fires on every reading | Its fire-once flag is not being set, or is cleared each time by the reading itself. |
+| The same alert repeats after a restart | The checkpoint was deleted, so every bin looks new. |
+| `COLLECTED` where no collection happened | Events processed out of order. `track_bin` sorts by `event_time`; check that sort survived an edit. |
+| Alerts duplicated in `bin_alerts` | The `(bin_id, alert_type, fired_at)` conflict key is missing. Retried micro-batches rely on it. |
+| Query fails on restart after editing rules | `STATE_SCHEMA` changed — delete the `bin_state` checkpoint. |
+
+## Which conditions are currently reachable
+
+```bash
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT alert_type, severity, count(*), max(fired_at) AS latest
+     FROM bin_alerts GROUP BY 1,2 ORDER BY 3 DESC;"
+```
+
+With fault injection on, all eleven types should appear given enough time.
+`FIRE_RISK` and `OFFLINE` will have the smallest counts — only a few bins carry
+those faults.
+
+## Inspecting one bin
+
+```bash
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT alert_type, fired_at, fill_pct, temperature, detail
+     FROM bin_alerts WHERE bin_id = 'BIN-XXXXXXXX-X' ORDER BY fired_at;"
+
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT * FROM bin_state_latest WHERE bin_id = 'BIN-XXXXXXXX-X';"
+```
+
+Every alert carries a `detail` string with the numbers that triggered it, which
+is usually faster than reasoning about the rule.
+
+## Reproducing a rule without the stack
+
+The rules are plain Python. To check one by hand:
+
+```bash
+cd services/stream-processor
+PYTHONPATH=src .venv/bin/python -c "
+from pipeline.bin_state import EMPTY_STATE, evaluate_reading
+memory = dict(EMPTY_STATE)
+reading = dict(zone='CENTRAL', capacity=100.0, current_fill_level=85.0,
+               fill_pct=85.0, temperature=25.0, battery_level=80.0,
+               latitude=17.4, longitude=78.5, sensor_faults=None,
+               event_ms=1755000000000)
+print([a['alert_type'] for a in evaluate_reading(memory, reading, 'BIN-1')])
+"
+```
+
+Or run the suite for one rule:
+
+```bash
+cd services/stream-processor && .venv/bin/python -m pytest tests/test_bin_state.py -k fire -v
+```

--- a/.claude/breadcrumbs/alert-detection/DETAILS.md
+++ b/.claude/breadcrumbs/alert-detection/DETAILS.md
@@ -33,26 +33,45 @@ every rule below describes the bin as it now is.
 |---|---|---|
 | `COLLECTED` | previous ≥ `COLLECTION_DROP_FROM_PCT` and now < `COLLECTION_DROP_TO_PCT` | clears both SLA clocks and every fire-once flag |
 | `ANOMALY_JUMP` | rise ≥ `ANOMALY_JUMP_PCT` since the previous reading | none |
-| `SENSOR_STUCK` | `unchanged_count` **equals** `STUCK_READING_COUNT` | `unchanged_count` |
+| `SENSOR_STUCK` | `unchanged_count` **equals** `STUCK_READING_COUNT`, below 100% | `unchanged_count` |
 | `CRITICAL_FILL` | ≥ `CRITICAL_FILL_PCT` and not already fired | `critical_fired`, `critical_since_ms` |
 | `OVERFLOW` | ≥ `OVERFLOW_FILL_PCT` and not already fired | `overflow_fired`, `overflow_since_ms` |
 | `PREDICTED_OVERFLOW` | projected full within 60 min, still below critical | `predicted_fired` |
 | `FIRE_RISK` | temp > `FIRE_RISK_TEMP_C` **and** fill > `FIRE_RISK_FILL_PCT` | `last_fire_risk_ms` |
 | `LOW_BATTERY` | < `LOW_BATTERY_PCT` and not already fired | `low_battery_fired` |
-| `SENSOR_FAULT` | `sensor_faults` set upstream and not already fired | `sensor_fault_fired` |
-| `SLA_BREACH` | a clock has run past its allowance | `sla_*_fired` |
+| `SENSOR_FAULT` | `sensor_faults` names a sensor not in `reported_faults` | `reported_faults` |
+| `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` | a clock has run past its allowance | `sla_*_fired` |
 
 Notes that are easy to get wrong:
 
 - `SENSOR_STUCK` uses `==`, not `>=`, so a permanently frozen sensor produces
   one alert rather than one per reading afterwards.
+- `SENSOR_STUCK` does not count readings at 100%, and **does** count them at 0%.
+  The two look symmetric and are not. Fill is clamped at capacity, so a bin
+  waiting for a truck reports exactly 100% every tick and identical readings
+  there say nothing about the sensor. Nothing clamps a bin at empty - waste
+  accumulates - so a bin repeating 0% has a sensor that stopped, which is what
+  the `FROZEN` fault produces. Excluding zero as well suppressed the alert for
+  every frozen bin in the fleet, because bins are seeded empty; an end-to-end
+  run caught that and the unit tests did not.
+- `CRITICAL_FILL` and `OVERFLOW` clear **only** on a collection. Clearing them
+  whenever the level fell back under the threshold looked equivalent and was
+  not - a bin wobbling around 80% re-alerted on every crossing and restarted
+  its SLA clock each time, so a bin nobody collected stayed inside its SLA
+  indefinitely.
+- `SENSOR_FAULT` compares fault *names*, not "any fault at all". A single
+  boolean meant a bin whose thermometer was already broken could lose its
+  battery reading with nobody told. Recovery needs no branch: the remembered
+  set is replaced by whatever the reading says.
 - `COLLECTED` and `ANOMALY_JUMP` are mutually exclusive (`elif`) — a collection
   is a large change, and reporting it as an anomaly too would be noise.
 - `FIRE_RISK` needs both halves. A hot empty bin is a warm day; a full cool bin
   is just a full bin. It is the only rule that re-fires while true, rate limited
   by `FIRE_RISK_REPEAT_MINUTES`.
-- `SLA_BREACH` checks overflow before critical, so the shorter clock is the one
-  reported when both have run out.
+- The two SLA breaches are separate alert types on purpose. Both clocks can
+  come due on the same reading, and `bin_alerts` keys on
+  `(bin_id, alert_type, fired_at)` - under one shared type the second row
+  collided with the first and was silently dropped on insert.
 - `fill_projection()` returns `(None, None)` from a single reading and a null
   `minutes_to_full` whenever the rate is not positive — a bin that just emptied
   has a negative rate, which would project to a nonsensical time.

--- a/.claude/breadcrumbs/alert-detection/DETAILS.md
+++ b/.claude/breadcrumbs/alert-detection/DETAILS.md
@@ -1,0 +1,80 @@
+# Alert Detection — Detailed Trace
+
+All in `services/stream-processor/src/pipeline/bin_state.py`.
+
+## Entry
+
+`evaluate()` wires `track_bin` into `applyInPandasWithState` with
+`OUTPUT_SCHEMA`, `STATE_SCHEMA`, append output and `EventTimeTimeout`.
+
+`track_bin(key, pdfs, state)`:
+
+1. `read_state(state)` returns the remembered values, or `EMPTY_STATE` for a bin
+   never seen before.
+2. If `state.hasTimedOut`, emit `OFFLINE` from the remembered values and return.
+   State is kept, not removed, so a bin that starts reporting again is
+   recognised as the same bin.
+3. Otherwise sort each frame by `event_time` and fold every row through
+   `evaluate_reading()`. **Spark makes no ordering promise within a batch**, and
+   every rule compares against the previous reading — out of order, a rise reads
+   as a drop and a collection is invented that never happened.
+4. `write_state(state, memory)` stores the tuple in `STATE_FIELDS` order.
+5. `state.setTimeoutTimestamp(max(last_event + offline_window, watermark + 1))`.
+   The clamp matters: Spark rejects a timeout already behind the watermark,
+   which is exactly what a late-arriving event asks for.
+6. Yield the alerts plus one `state_record`, as a single pandas frame.
+
+## The rules, in order
+
+`evaluate_reading(memory, reading, bin_id)` updates `memory` in place first, so
+every rule below describes the bin as it now is.
+
+| Rule | Condition | State touched |
+|---|---|---|
+| `COLLECTED` | previous ≥ `COLLECTION_DROP_FROM_PCT` and now < `COLLECTION_DROP_TO_PCT` | clears both SLA clocks and every fire-once flag |
+| `ANOMALY_JUMP` | rise ≥ `ANOMALY_JUMP_PCT` since the previous reading | none |
+| `SENSOR_STUCK` | `unchanged_count` **equals** `STUCK_READING_COUNT` | `unchanged_count` |
+| `CRITICAL_FILL` | ≥ `CRITICAL_FILL_PCT` and not already fired | `critical_fired`, `critical_since_ms` |
+| `OVERFLOW` | ≥ `OVERFLOW_FILL_PCT` and not already fired | `overflow_fired`, `overflow_since_ms` |
+| `PREDICTED_OVERFLOW` | projected full within 60 min, still below critical | `predicted_fired` |
+| `FIRE_RISK` | temp > `FIRE_RISK_TEMP_C` **and** fill > `FIRE_RISK_FILL_PCT` | `last_fire_risk_ms` |
+| `LOW_BATTERY` | < `LOW_BATTERY_PCT` and not already fired | `low_battery_fired` |
+| `SENSOR_FAULT` | `sensor_faults` set upstream and not already fired | `sensor_fault_fired` |
+| `SLA_BREACH` | a clock has run past its allowance | `sla_*_fired` |
+
+Notes that are easy to get wrong:
+
+- `SENSOR_STUCK` uses `==`, not `>=`, so a permanently frozen sensor produces
+  one alert rather than one per reading afterwards.
+- `COLLECTED` and `ANOMALY_JUMP` are mutually exclusive (`elif`) — a collection
+  is a large change, and reporting it as an anomaly too would be noise.
+- `FIRE_RISK` needs both halves. A hot empty bin is a warm day; a full cool bin
+  is just a full bin. It is the only rule that re-fires while true, rate limited
+  by `FIRE_RISK_REPEAT_MINUTES`.
+- `SLA_BREACH` checks overflow before critical, so the shorter clock is the one
+  reported when both have run out.
+- `fill_projection()` returns `(None, None)` from a single reading and a null
+  `minutes_to_full` whenever the rate is not positive — a bin that just emptied
+  has a negative rate, which would project to a nonsensical time.
+
+## State
+
+`STATE_SCHEMA` is a positional tuple. `read_state`/`write_state` zip it against
+`STATE_FIELDS`, so a field added to the schema without a matching `EMPTY_STATE`
+entry shifts every value one place. `test_state_survives_a_round_trip_through_storage`
+guards that.
+
+Changing `STATE_SCHEMA` makes existing checkpoints unreadable. Delete the
+`bin_state` checkpoint after any change to it.
+
+Roughly 200 bytes per bin, about a megabyte for a 5,000-bin city.
+
+## Testing
+
+`tests/test_bin_state.py` drives the rules with plain dictionaries and a
+`FakeGroupState` — no Spark session, 47 tests in under a second. Every rule has
+a positive case and a must-not-fire case.
+
+`tests/test_streaming.py::test_the_stateful_operator_runs_under_spark` covers
+only what the fast tests cannot: that the state schema round-trips through
+Spark's state store and the emitted frames match `OUTPUT_SCHEMA`.

--- a/.claude/breadcrumbs/alert-detection/FLOW.md
+++ b/.claude/breadcrumbs/alert-detection/FLOW.md
@@ -17,12 +17,13 @@ clean_events
         STATE → bin_state_latest  (upsert on bin_id)
 ```
 
-Eleven alert types come out of one state read per event:
+Twelve alert types come out of one state read per event:
 
 | Fires once, cleared by | Types |
 |---|---|
-| collection | `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `SLA_BREACH` |
-| the condition ending | `LOW_BATTERY`, `SENSOR_FAULT` |
+| collection | `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` |
+| the condition ending | `LOW_BATTERY` |
+| each newly named sensor | `SENSOR_FAULT` |
 | crossing the threshold | `SENSOR_STUCK` |
 | — (per event) | `COLLECTED`, `ANOMALY_JUMP` |
 | repeats on an interval | `FIRE_RISK` |
@@ -33,4 +34,7 @@ not: a bare filter re-fires for as long as the condition holds, so one bin stuck
 at 88% produces an alert every few seconds forever. Firing once needs per-bin
 memory, which is why they live here.
 
-Thresholds are all in `src/config.py`, not scattered through the rules.
+Thresholds are all in `src/config.py`, not scattered through the rules - and
+the `city_kpi` and `zone_leaderboard` views are built from the same settings at
+startup, so the dashboard cannot disagree with the alerts about what "critical"
+or "offline" means.

--- a/.claude/breadcrumbs/alert-detection/FLOW.md
+++ b/.claude/breadcrumbs/alert-detection/FLOW.md
@@ -1,0 +1,36 @@
+# Alert Detection
+
+Trigger: the `bin_state` streaming query, started from `src/main.py`.
+
+```text
+clean_events
+  → groupBy("bin_id").applyInPandasWithState(track_bin, EventTimeTimeout)
+  → per bin, per batch:
+        read state
+        sort this batch's events by event_time
+        fold each reading through evaluate_reading()
+        write state
+        arm timeout at last_event + OFFLINE_AFTER_MINUTES
+  → emit alert rows + one state row (record_type discriminates)
+  → foreachBatch splits them:
+        ALERT → bin_alerts        (insert, on conflict do nothing)
+        STATE → bin_state_latest  (upsert on bin_id)
+```
+
+Eleven alert types come out of one state read per event:
+
+| Fires once, cleared by | Types |
+|---|---|
+| collection | `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `SLA_BREACH` |
+| the condition ending | `LOW_BATTERY`, `SENSOR_FAULT` |
+| crossing the threshold | `SENSOR_STUCK` |
+| — (per event) | `COLLECTED`, `ANOMALY_JUMP` |
+| repeats on an interval | `FIRE_RISK` |
+| a timer, not a rule | `OFFLINE` |
+
+`CRITICAL_FILL`, `LOW_BATTERY` and `FIRE_RISK` look like plain filters. They are
+not: a bare filter re-fires for as long as the condition holds, so one bin stuck
+at 88% produces an alert every few seconds forever. Firing once needs per-bin
+memory, which is why they live here.
+
+Thresholds are all in `src/config.py`, not scattered through the rules.

--- a/.claude/breadcrumbs/fault-injection/DEBUG.md
+++ b/.claude/breadcrumbs/fault-injection/DEBUG.md
@@ -1,0 +1,78 @@
+# Fault Injection — Debug Guide
+
+## Is it even on?
+
+```bash
+docker logs data_simulator 2>&1 | grep Injected
+# Injected faults into 30 of 200 bin(s).
+```
+
+No line means `faulty_count` was zero. Either `FAULT_INJECTION_RATE=0`, the
+fleet is too small for the rate to round up to one bin, or — the common one —
+the container is running an image built before the change:
+
+```bash
+docker compose build data_simulator
+docker compose up -d --force-recreate data_simulator
+```
+
+`restart` is not enough; it reuses the old image.
+
+## Symptom routing
+
+| Symptom | Check |
+|---|---|
+| No faults logged | See above. Rebuild before anything else. |
+| One mode's detector never fires | With a small fleet, `int(len * rate)` may not reach that mode's index. Raise the count or the rate. |
+| `SLA_BREACH` missing | Only `UNCOLLECTED` bins can breach, and only after `SLA_CRITICAL_MINUTES`. Hours on the default profile. |
+| `LOW_BATTERY` missing | Battery has not drained to 20% yet. ~2 hours by default. |
+| `FIRE_RISK` missing | A `HOT` bin must also be nearly full. If bins are collected before 80%, check `COLLECTION_THRESHOLD_PCT` is above 80. |
+| Duplicates not being removed | The duplicate must carry the original timestamp. Confirm `_next_payload` is not regenerating the payload. |
+| Bins missing from `bin_state_latest` | `SPIKE` bins sending an impossible fill level are dead-lettered. A `SPIKE` bin should still appear via its alternating temperature readings. |
+| Bins never go critical | Fill rate versus `COLLECTION_THRESHOLD_PCT` — bins may be emptied before reaching 80%. |
+
+## Which bins carry which fault
+
+Fault mode is in-memory only and is not persisted, so it cannot be queried from
+PostgreSQL. Assignment is deterministic by position in the fleet load order,
+which the debug log reports:
+
+```bash
+docker logs data_simulator 2>&1 | grep -iE "silent|frozen|re-sending|emptied" | head -20
+```
+
+Enable debug logging first (`SIGUSR1` on a native process, or set the level in
+`logging_config.py`). Otherwise, identify them by behaviour:
+
+```bash
+# SPIKE bins - the only ones in the dead-letter topic
+docker exec smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-dlq \
+  --from-beginning --max-messages 200 --timeout-ms 30000 2>/dev/null \
+  | grep -oE 'bin_id\\": \\"[A-Z0-9-]+' | sed 's/.*"//' | sort -u
+
+# SILENT bins - the stalest last_seen
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT bin_id, last_seen FROM bin_state_latest ORDER BY last_seen LIMIT 10;"
+
+# HOT bins - at or near TEMP_FIRE_MAX
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT bin_id, temperature, fill_pct FROM bin_state_latest
+    WHERE temperature > 60 ORDER BY temperature DESC;"
+
+# SPIKE bins with a nulled sensor, still tracked
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT bin_id, sensor_faults FROM bin_state_latest
+    WHERE sensor_faults IS NOT NULL;"
+```
+
+## Turning it off
+
+`FAULT_INJECTION_RATE=0` in `.env.docker`, then rebuild-free restart is enough
+since it is read from the environment:
+
+```bash
+docker compose up -d --force-recreate data_simulator
+```
+
+Existing alerts stay in `bin_alerts`; only new ones stop.

--- a/.claude/breadcrumbs/fault-injection/DEBUG.md
+++ b/.claude/breadcrumbs/fault-injection/DEBUG.md
@@ -24,7 +24,7 @@ docker compose up -d --force-recreate data_simulator
 |---|---|
 | No faults logged | See above. Rebuild before anything else. |
 | One mode's detector never fires | With a small fleet, `int(len * rate)` may not reach that mode's index. Raise the count or the rate. |
-| `SLA_BREACH` missing | Only `UNCOLLECTED` bins can breach, and only after `SLA_CRITICAL_MINUTES`. Hours on the default profile. |
+| `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` missing | Only `UNCOLLECTED` bins can breach, and only after `SLA_CRITICAL_MINUTES`. Hours on the default profile. |
 | `LOW_BATTERY` missing | Battery has not drained to 20% yet. ~2 hours by default. |
 | `FIRE_RISK` missing | A `HOT` bin must also be nearly full. If bins are collected before 80%, check `COLLECTION_THRESHOLD_PCT` is above 80. |
 | Duplicates not being removed | The duplicate must carry the original timestamp. Confirm `_next_payload` is not regenerating the payload. |

--- a/.claude/breadcrumbs/fault-injection/DETAILS.md
+++ b/.claude/breadcrumbs/fault-injection/DETAILS.md
@@ -52,7 +52,7 @@ impossible fill level leaves nothing usable and is dead-lettered whole.
 
 ## Pacing interacts with faults
 
-`SLA_BREACH` needs a bin uncollected past `SLA_CRITICAL_MINUTES`, so on the
+`SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` needs a bin uncollected past `SLA_CRITICAL_MINUTES`, so on the
 default profile it is hours away. `LOW_BATTERY` needs the battery to drain to
 20%. The demo profile in `.env.local.example` compresses both. See
 `src/config.py` for what each knob does and why the default is what it is.

--- a/.claude/breadcrumbs/fault-injection/DETAILS.md
+++ b/.claude/breadcrumbs/fault-injection/DETAILS.md
@@ -1,0 +1,71 @@
+# Fault Injection — Detailed Trace
+
+Paths are relative to `services/data-simulator/`.
+
+`FAULT_MODES` and `assign_fault_modes()` live in
+`src/simulator/bin_simulator.py`. `Bin.fault_mode` is only a label — the bin
+holds no logic, in keeping with the rest of that class.
+
+## Assignment
+
+`SimulationManager.initialize()` builds every `Bin` first, calls
+`assign_fault_modes(bins)` on the whole list, then starts the simulators.
+Fleet-wide rather than per bin, so both the share of faulty bins and the spread
+of modes are known rather than left to chance. `int(len(bins) * rate)` bins are
+marked, cycling `FAULT_MODES` by index.
+
+## Two kinds of fault
+
+**State-level**, in `_simulate()` — the bin really behaves this way:
+
+- `FROZEN` returns before any state changes, so every reading repeats.
+- `JUMP` sets the increase to `capacity * 0.4`. Large but still a level the bin
+  could hold, so it passes validation and must be caught by comparing against
+  the previous reading.
+- `UNCOLLECTED` is excluded from the collection check, so it is never emptied.
+- `HOT` replaces the ambient drift with
+  `TEMP_NORMAL_MAX + (TEMP_FIRE_MAX - TEMP_NORMAL_MAX) * fill_pct / 100`.
+  Scaling with fill is what makes fire risk reachable: the rule needs hot **and**
+  nearly full together, so a bin pinned hot while empty would satisfy one half
+  forever and the other never. It also needs no retuning when capacity or fill
+  rate change.
+
+**Reporting-level**, in `_next_payload()` — the bin is fine, the telemetry is
+not:
+
+- `SILENT` publishes normally for `SILENCE_AFTER_READINGS` readings, then stops.
+  It must report at least once: dead-device detection arms a timer when a bin
+  reports, so a bin never heard from is not detected as dead, it is simply never
+  known about.
+- `DUPLICATE` re-sends `_last_payload` **verbatim, original timestamp
+  included**. Deduplication keys on `(bin_id, event_time)`, so a regenerated
+  timestamp makes it a distinct event that passes straight through. It
+  alternates, so the bin still makes progress.
+- `SPIKE` calls `_corrupt()`, which copies the payload and alternates between
+  `temperature = IMPOSSIBLE_TEMPERATURE` (150 °C) and
+  `current_fill_level = capacity * 1.5`. The bin's own state is untouched, which
+  is what a broken sensor actually is — and what keeps the bin worth tracking.
+
+The two `SPIKE` corruptions are treated differently downstream, which is why it
+alternates: an impossible temperature is nulled and the reading kept, while an
+impossible fill level leaves nothing usable and is dead-lettered whole.
+
+## Pacing interacts with faults
+
+`SLA_BREACH` needs a bin uncollected past `SLA_CRITICAL_MINUTES`, so on the
+default profile it is hours away. `LOW_BATTERY` needs the battery to drain to
+20%. The demo profile in `.env.local.example` compresses both. See
+`src/config.py` for what each knob does and why the default is what it is.
+
+`COLLECTION_THRESHOLD_PCT` must stay **above** the consumer's critical threshold
+of 80. Below it, bins are emptied on the way up and never once register as
+critical — no collection list, no SLA clock, and no fire risk, since that rule
+needs a nearly full bin.
+
+## Testing
+
+`tests/simulator/test_faults.py` asserts each mode produces the condition its
+detector looks for, not merely that a flag was set — a fault that never produces
+its condition and a detector that never fires are indistinguishable in a demo.
+It also covers assignment: full coverage of modes at a high rate, the configured
+share at the default, and nothing at zero.

--- a/.claude/breadcrumbs/fault-injection/FLOW.md
+++ b/.claude/breadcrumbs/fault-injection/FLOW.md
@@ -1,0 +1,33 @@
+# Fault Injection
+
+Trigger: `SimulationManager.initialize()`, once at simulator startup.
+
+```text
+load ACTIVE bins from smart_bins
+  → build every Bin
+  → assign_fault_modes(bins)          # int(len * FAULT_INJECTION_RATE) bins
+       index 0,1,2,... cycle through FAULT_MODES
+  → start one BinSimulator per bin
+  → each tick: _simulate() applies state-level faults
+               _next_payload() applies reporting-level faults
+```
+
+Faults exist so the detectors downstream have something to detect. Without them
+the offline, stuck-sensor, duplicate, sensor-fault, fire-risk and SLA rules can
+be written but never once observed working.
+
+| Mode | Applied in | Proves |
+|---|---|---|
+| `SILENT` | `_next_payload` | `OFFLINE` |
+| `FROZEN` | `_simulate` | `SENSOR_STUCK` |
+| `SPIKE` | `_next_payload` (`_corrupt`) | `SENSOR_FAULT` and the dead-letter path |
+| `DUPLICATE` | `_next_payload` | deduplication |
+| `HOT` | `_simulate_temperature` | `FIRE_RISK` |
+| `JUMP` | `_simulate_fill` | `ANOMALY_JUMP` |
+| `UNCOLLECTED` | `_simulate_fill` | `SLA_BREACH` |
+
+Assignment cycles rather than drawing per bin. Independent draws can leave a
+small fleet with no `HOT` bin at all, so no fire alert appears anywhere in the
+run — indistinguishable from a broken detector.
+
+Set `FAULT_INJECTION_RATE=0` for a fleet where nothing ever goes wrong.

--- a/.claude/breadcrumbs/fault-injection/FLOW.md
+++ b/.claude/breadcrumbs/fault-injection/FLOW.md
@@ -24,7 +24,7 @@ be written but never once observed working.
 | `DUPLICATE` | `_next_payload` | deduplication |
 | `HOT` | `_simulate_temperature` | `FIRE_RISK` |
 | `JUMP` | `_simulate_fill` | `ANOMALY_JUMP` |
-| `UNCOLLECTED` | `_simulate_fill` | `SLA_BREACH` |
+| `UNCOLLECTED` | `_simulate_fill` | `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` |
 
 Assignment cycles rather than drawing per bin. Independent draws can leave a
 small fleet with no `HOT` bin at all, so no fire alert appears anywhere in the

--- a/.claude/breadcrumbs/graceful-shutdown/FLOW.md
+++ b/.claude/breadcrumbs/graceful-shutdown/FLOW.md
@@ -12,3 +12,11 @@ SIGINT or SIGTERM
 ```
 
 Windows uses `signal.signal`; other platforms use event-loop signal handlers.
+
+Cleanup runs from a `finally`, so it happens whether startup succeeded or not.
+It previously sat after the shutdown wait, which never runs if startup raises -
+a failed start therefore leaked the Kafka producer and the process died
+complaining about that instead of about the real problem.
+
+Each step is separately guarded, so one failing step cannot skip the ones after
+it. A normal shutdown ends with `Shutdown complete`, no warnings, exit code 0.

--- a/.claude/breadcrumbs/graceful-shutdown/FLOW.md
+++ b/.claude/breadcrumbs/graceful-shutdown/FLOW.md
@@ -20,3 +20,26 @@ complaining about that instead of about the real problem.
 
 Each step is separately guarded, so one failing step cannot skip the ones after
 it. A normal shutdown ends with `Shutdown complete`, no warnings, exit code 0.
+
+## The stream processor
+
+Different shape, same requirement. `src/main.py` cannot simply block:
+
+```text
+SIGINT or SIGTERM
+  → handle_shutdown sets stop_requested
+  → run() notices it between polls of awaitAnyTermination(timeout=5)
+  → query.stop() for each active query, by name
+  → session.stop()
+  → log shutdown complete
+```
+
+The timeout is the whole point. Python runs a signal handler between bytecodes,
+so while the main thread sits inside an unbounded py4j call the handler never
+runs — SIGTERM was ignored and Docker sent SIGKILL after ten seconds, making
+every ordinary stop report as exit 137. The service also carries
+`stop_grace_period: 60s`, because four queries need longer than the default to
+finish their micro-batches.
+
+Nothing is lost either way: checkpoints exist for a kill, and every write is
+idempotent. What is lost is the ability to tell a crash from a stop.

--- a/.claude/breadcrumbs/schema-migrations/DEBUG.md
+++ b/.claude/breadcrumbs/schema-migrations/DEBUG.md
@@ -1,5 +1,27 @@
 # Schema Migrations — Debug Guide
 
+## Reading the output
+
+An upgrade reports every revision it applies:
+
+```text
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade  -> 9b7a1e20a036, Create the initial smart_bins schema.
+INFO  [alembic.runtime.migration] Running upgrade 9b7a1e20a036 -> 0002_add_zone, Add zone to smart_bins and backfill existing rows.
+```
+
+Only the first two lines means the database was already at head — nothing to do,
+which is not the same as nothing happening.
+
+**No output at all** means logging is not configured. `alembic.ini` needs its
+`[loggers]`/`[handlers]`/`[formatters]` sections *and* `env.py` must call
+`fileConfig`; either one alone is silent. A silent upgrade is dangerous
+precisely because a migration that did nothing looks identical to one that
+worked.
+
+To see the SQL as well, raise `logger_sqlalchemy` to `INFO` in `alembic.ini`.
+
 ## Commands
 
 ```bash
@@ -27,6 +49,7 @@ docker compose run --rm data_simulator alembic history --indicate-current
 | `relation "smart_bins" does not exist` | Run `alembic upgrade head` before seeding. |
 | `table smart_bins already exists` on baseline upgrade | The table predates Alembic and has no marker. Verify its columns, then stamp `9b7a1e20a036` and upgrade. |
 | `alembic check` reports operations | ORM metadata changed without a matching revision. Generate and review a migration. |
+| Upgrade prints nothing at all | Logging is unconfigured, or the image is stale. Rebuild first — the ini and `env.py` are copied into the image. |
 
 Never stamp an unknown schema or downgrade below `9b7a1e20a036` on valuable
 data: the baseline downgrade drops `smart_bins`.

--- a/.claude/breadcrumbs/startup-and-telemetry/DEBUG.md
+++ b/.claude/breadcrumbs/startup-and-telemetry/DEBUG.md
@@ -25,3 +25,6 @@ docker exec smartbin_kafka kafka-console-consumer \
 ```
 
 Runtime fleet size comes from active rows, not `NUMBER_OF_BINS`.
+
+Some bins are silent, frozen or publishing impossible values on purpose. Before
+treating that as a bug, check [`fault-injection`](../fault-injection/DEBUG.md).

--- a/.claude/breadcrumbs/startup-and-telemetry/DEBUG.md
+++ b/.claude/breadcrumbs/startup-and-telemetry/DEBUG.md
@@ -3,9 +3,30 @@
 Logs go to the color console and rotating `logs/simulator.log`. `SIGUSR1`
 toggles debug logging for a native process.
 
+### The two ways startup fails
+
+Migrations are a deliberate manual step, so both bad states are ordinary and
+both now answer themselves:
+
+- **Not migrated** — `The 'smart_bins' table does not exist.` followed by the
+  commands to run. The process exits 1 after releasing the Kafka producer and
+  the engine. A raw SQLAlchemy traceback here instead means the image is stale.
+- **Migrated but unseeded** — a warning naming the seed command. Not fatal; the
+  process keeps running and publishes nothing.
+
+### A healthy simulator logs nothing
+
+Per-tick telemetry is DEBUG. `docker logs data_simulator -f` showing no output
+after `Started N simulator(s).` means it is working. Confirm activity from
+Kafka or `bin_state_latest` rather than the log, or raise the level with
+`SIGUSR1`.
+
 | Symptom | Check |
 |---|---|
-| `Started 0 simulator(s)` | Query `smart_bins` for active rows and seed if empty. |
+| `No ACTIVE bins found` | Seed the database; the message carries the command. |
+| `The 'smart_bins' table does not exist` | Run `alembic upgrade head` first. |
+| Raw SQLAlchemy traceback on startup | Stale image. `docker compose build data_simulator`. |
+| `Unclosed AIOKafkaProducer` | Cleanup was skipped on an error path. Should not happen — startup and shutdown both run cleanup in a `finally`. |
 | Kafka connection retries | Verify `KAFKA_BOOTSTRAP_SERVERS` for Docker versus native execution. |
 | Send failures | Search logs for `Failed to send telemetry`. Messages are dropped, not retried. |
 | Payload lacks zone or temperature | Rebuild and force-recreate the simulator container; do not judge new format with `--from-beginning`. |

--- a/.claude/breadcrumbs/startup-and-telemetry/DETAILS.md
+++ b/.claude/breadcrumbs/startup-and-telemetry/DETAILS.md
@@ -5,14 +5,28 @@ Paths are relative to `services/data-simulator/`.
 1. `src/main.py` configures logging and awaits `kafka_client.start()`.
 2. `SimulationManager.initialize()` selects only `SmartBin.status == "ACTIVE"`.
 3. Each database row becomes a `Bin` carrying ID, capacity, coordinates, and
-   zone, then a `BinSimulator` task is started and registered by ID.
-4. `BinSimulator._run()` calls `_simulate()`, publishes `Bin.to_payload()`, and
-   sleeps for the configured interval.
-5. `_simulate()` updates fill, battery, and temperature. Fill and battery use
-   Faker; signed temperature drift uses `random.uniform` and stays within
-   `20..35 °C`.
+   zone. `assign_fault_modes()` marks a share of the fleet, then a
+   `BinSimulator` task is started per bin and registered by ID.
+4. `BinSimulator._run()` calls `_simulate()`, then `_next_payload()`, and
+   publishes only if that returned something. It sleeps for the configured
+   interval.
+5. `_simulate()` delegates to `_simulate_fill()`, `_simulate_battery()` and
+   `_simulate_temperature()`.
+   - Fill rises by a percentage of capacity (`FILL_RATE_PCT_MIN/MAX`), so bins
+     of every size cross percentage thresholds at the same pace. A bin is
+     emptied only above `COLLECTION_THRESHOLD_PCT`, which sits above the
+     consumer's critical threshold — below it, bins would be emptied on the way
+     up and never register as critical.
+   - Battery drains by `BATTERY_DRAIN_MIN/MAX` and never goes below zero.
+   - Temperature drifts within `TEMP_NORMAL_MIN..TEMP_NORMAL_MAX`, unless the
+     bin carries the `HOT` fault, which scales it up to `TEMP_FIRE_MAX`.
 6. `Bin.to_payload()` emits capacity, dynamic readings, coordinates, zone, and
-   an aware UTC timestamp.
+   an aware UTC timestamp. `Bin.fill_pct` is available but is not published;
+   consumers derive it from level and capacity.
+   `_next_payload()` then applies the reporting-level faults — suppressing the
+   message, re-sending the previous one verbatim, or corrupting a field.
+   The published shape is asserted against `contracts/telemetry-v1.json` by
+   `tests/test_contract.py`.
 7. `KafkaClient.send_telemetry()` JSON-serializes the payload and publishes it
    to `KAFKA_TOPIC` with the UTF-8 bin ID as key.
 

--- a/.claude/breadcrumbs/startup-and-telemetry/FLOW.md
+++ b/.claude/breadcrumbs/startup-and-telemetry/FLOW.md
@@ -8,12 +8,17 @@ setup logging
   → create SimulationManager
   → SELECT active SmartBin rows
   → build Bin with capacity, coordinates, and zone
+  → assign_fault_modes over the whole fleet
   → start one BinSimulator asyncio task per row
   → each tick updates fill, battery, and temperature
   → Bin.to_payload adds static metadata and UTC timestamp
+  → _next_payload may suppress, repeat, or corrupt it
   → publish JSON to KAFKA_TOPIC keyed by bin_id
   → sleep SIMULATION_INTERVAL
 ```
+
+A share of bins misbehave on purpose so the detectors downstream have something
+to detect. See [`fault-injection`](../fault-injection/FLOW.md).
 
 The manager loads the database once. Seeded or edited rows require a process
 restart; after rebuilding a Docker image, use `docker compose up -d

--- a/.claude/breadcrumbs/stream-processing/DEBUG.md
+++ b/.claude/breadcrumbs/stream-processing/DEBUG.md
@@ -30,6 +30,12 @@ this pipeline cannot.
 | Rows duplicated in an output table | A conflict key is missing or wrong in `sql/schema.sql`. Retried micro-batches rely on it. |
 | Query fails on restart after a code change | `STATE_SCHEMA` changed. Spark cannot restore state written under a different schema — delete the `bin_state` checkpoint. |
 | `SparkUI could not bind on port ...` | Ports are now bound explicitly with no retry, so this means something else already holds it. Check for a second stream-processor container. |
+| Bins that stopped early never appear at all | A fresh checkpoint reads from `earliest` for exactly this reason — a `SILENT` bin publishes a handful of readings and stops, and `latest` skipped them while Spark was still building its queries. If they are missing anyway, check `STARTING_OFFSETS` has not been set back. |
+| A zero-`capacity` message kills the application | It should be dead-lettered as `capacity_out_of_range`. If it reaches the operator, `fill_pct` arrives null and every fill rule raises on the comparison. Check `range_rules()` still carries the exclusivity flag. |
+| `zone_hourly_profile` / `zone_daily_trend` stay empty | The `rollups` container writes them, not the streaming app. `docker compose ps rollups`, then its logs. |
+| The rollup logs "No history" every run | That check is `Path.exists()` on `PARQUET_PATH` — so the directory really is absent, not a swallowed read error. Confirm `bin_events` is being written and the volume is shared. |
+| `city_kpi` disagrees with the alerts | The views are built from the settings when the schema is applied. A changed threshold needs the stream processor restarted, not just the simulator. |
+| `stream_processor` exits 137 on stop | SIGKILL after the grace period. `main.run()` polls `awaitAnyTermination` on a timeout so the handler can run - an unbounded wait swallows the signal, because Python cannot run a handler while the main thread is inside a py4j call. Also check `stop_grace_period` is still on the service. |
 
 ## Start at the Spark UI
 
@@ -39,7 +45,9 @@ size — none of which appears in the logs, and all of which answers "is this
 query stalled, starved, or just waiting for the watermark" faster than any
 query against PostgreSQL.
 
-The batch job is on <http://localhost:4041> while it runs.
+The batch job is on <http://localhost:4041> while it runs — it lives in the
+`rollups` container and runs every `ROLLUP_INTERVAL_SECONDS` (default 900), so
+that port is only live for the length of each run.
 
 If a query is missing from that tab it never started; check the logs for the
 `Started 4 streaming quer(ies)` line.

--- a/.claude/breadcrumbs/stream-processing/DEBUG.md
+++ b/.claude/breadcrumbs/stream-processing/DEBUG.md
@@ -1,0 +1,78 @@
+# Stream Processing — Debug Guide
+
+Logs go to the color console and rotating `logs/stream-processor.log`. `py4j` is
+pinned to WARNING or it buries everything else. `SIGUSR1` toggles debug logging.
+
+## The two that look like bugs and are not
+
+**Empty `zone_metrics_5m`, no `OFFLINE` alerts.** Both are gated by the
+watermark, not by how fast bins fill. A window is only written once the
+watermark passes its end, and an offline timeout only fires once it passes the
+bin's deadline. With the default `WATERMARK` of 10 minutes, expect ~15 minutes
+before the first window lands. Lower `WATERMARK` for a demo. Everything else
+appears within a minute or two.
+
+**An offline timeout fires because *other* bins are still reporting.** The
+watermark advances on stream progress. If the entire simulator stops, no
+`OFFLINE` alert is produced at all, because Spark cannot distinguish "every bin
+died" from "the stream ended". A liveness check on Kafka lag covers that case;
+this pipeline cannot.
+
+## Symptom routing
+
+| Symptom | Check |
+|---|---|
+| `ModuleNotFoundError: distutils` | Python 3.12. PySpark 3.5 supports up to 3.11; the image pins it. Locally, `setuptools` restores the shim. |
+| `ModuleNotFoundError` for `pandas`, `pyarrow`, or a project module, from inside a Spark stack trace | Spark's workers launched under a different interpreter. `ensure_worker_interpreter()` handles it; in tests `conftest.py` also sets `PYTHONPATH`. |
+| Contract not found at startup | `config.CONTRACT_PATH` searches upward for `contracts/telemetry-v1.json`. The image copies it to `/app/contracts/`; the build context must be the repo root. |
+| Every alert type but one is firing | Check fault injection is on — see [`fault-injection`](../fault-injection/DEBUG.md). |
+| Bins missing from `bin_state_latest` | Their messages are being dead-lettered. Query the DLQ and compare bin IDs (below). |
+| Rows duplicated in an output table | A conflict key is missing or wrong in `sql/schema.sql`. Retried micro-batches rely on it. |
+| Query fails on restart after a code change | `STATE_SCHEMA` changed. Spark cannot restore state written under a different schema — delete the `bin_state` checkpoint. |
+| `SparkUI could not bind on port 4040` | The streaming app holds it; the batch job took 4041. Harmless. |
+
+## Checkpoints are not a cache
+
+`/data/checkpoints` holds every SLA clock, last-seen timestamp and deduplication
+key in the fleet. `docker compose down -v` erases the pipeline's memory, not its
+scratch space. Delete one query's directory to reset only that query:
+
+```bash
+docker compose exec stream_processor rm -rf /data/checkpoints/bin_state
+docker compose restart stream_processor
+```
+
+## Commands
+
+```bash
+# Which bins are being dead-lettered, and are therefore absent downstream
+docker exec smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-dlq \
+  --from-beginning --max-messages 200 --timeout-ms 30000 2>/dev/null \
+  | grep -oE 'bin_id\\": \\"[A-Z0-9-]+' | sed 's/.*"//' | sort -u
+
+# Seeded bins that never reached the state store
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT bin_id FROM smart_bins s WHERE NOT EXISTS
+     (SELECT 1 FROM bin_state_latest b WHERE b.bin_id = s.bin_id);"
+
+# Bins reporting a broken sensor but still tracked
+docker exec smartbin_postgres psql -U postgres -d smart_city -c \
+  "SELECT bin_id, sensor_faults, fill_pct FROM bin_state_latest
+    WHERE sensor_faults IS NOT NULL;"
+
+# Query health
+docker logs stream_processor 2>&1 | grep -E "Started 4 streaming|ERROR"
+```
+
+Two independent implementations of "a collection" exist — the streaming rule and
+the batch window function. Comparing them is a useful cross-check:
+
+```bash
+docker exec smartbin_postgres psql -U postgres -d smart_city -tAc \
+  "SELECT (SELECT sum(collections) FROM zone_daily_trend),
+          (SELECT count(*) FROM bin_alerts WHERE alert_type='COLLECTED');"
+```
+
+They should agree within the events in flight between the two queries' triggers.
+A large gap means one of the two rules has drifted.

--- a/.claude/breadcrumbs/stream-processing/DEBUG.md
+++ b/.claude/breadcrumbs/stream-processing/DEBUG.md
@@ -29,7 +29,20 @@ this pipeline cannot.
 | Bins missing from `bin_state_latest` | Their messages are being dead-lettered. Query the DLQ and compare bin IDs (below). |
 | Rows duplicated in an output table | A conflict key is missing or wrong in `sql/schema.sql`. Retried micro-batches rely on it. |
 | Query fails on restart after a code change | `STATE_SCHEMA` changed. Spark cannot restore state written under a different schema — delete the `bin_state` checkpoint. |
-| `SparkUI could not bind on port 4040` | The streaming app holds it; the batch job took 4041. Harmless. |
+| `SparkUI could not bind on port ...` | Ports are now bound explicitly with no retry, so this means something else already holds it. Check for a second stream-processor container. |
+
+## Start at the Spark UI
+
+<http://localhost:4040>, **Structured Streaming** tab. Per query it reports
+input rate, processing rate, batch duration, watermark position and state store
+size — none of which appears in the logs, and all of which answers "is this
+query stalled, starved, or just waiting for the watermark" faster than any
+query against PostgreSQL.
+
+The batch job is on <http://localhost:4041> while it runs.
+
+If a query is missing from that tab it never started; check the logs for the
+`Started 4 streaming quer(ies)` line.
 
 ## Checkpoints are not a cache
 

--- a/.claude/breadcrumbs/stream-processing/DETAILS.md
+++ b/.claude/breadcrumbs/stream-processing/DETAILS.md
@@ -1,0 +1,58 @@
+# Stream Processing — Detailed Trace
+
+Paths are relative to `services/stream-processor/`.
+
+1. `src/main.py` calls `setup_logging()`, then `sinks.apply_schema()` executes
+   `sql/schema.sql` through psycopg2. The file is `CREATE ... IF NOT EXISTS`
+   throughout, so a restart never destroys accumulated history.
+2. `session.build_session()` calls `ensure_worker_interpreter()` first, which
+   points `PYSPARK_PYTHON` at `sys.executable`. Without it Spark launches its
+   workers as bare `python3` and pandas operators fail on a missing import.
+3. The session sets `RocksDBStateStoreProvider` with changelog checkpointing,
+   `spark.sql.shuffle.partitions=12`, and UTC as the session time zone.
+4. `session.read_telemetry()` opens the Kafka source with `startingOffsets`,
+   `maxOffsetsPerTrigger` and `failOnDataLoss=false`. It returns the raw
+   records, not parsed ones, because the dead-letter path needs the original
+   bytes.
+5. `pipeline.clean.parse()` casts `value` to string, applies
+   `schema.telemetry_schema()` — built from `contracts/telemetry-v1.json`, not
+   restated in code — and derives `event_time` from the ISO `timestamp` field.
+6. `pipeline.clean.split_valid_and_rejected()` computes two columns:
+   - `rejection_reason` covers only `TRACKING_FIELDS` plus the cross-field check
+     `current_fill_level > capacity`. These make a message unusable.
+   - `sensor_fault_reason` covers `REPAIRABLE_FIELDS`. These are nulled by
+     `repair()` and the reading is kept, so a bin with one failed sensor stays
+     tracked instead of vanishing from monitoring.
+   Bounds for both come from the contract via `schema.range_rules()`.
+7. `clean_events()` applies the watermark, then
+   `dropDuplicatesWithinWatermark(["bin_id", "event_time"])`, then computes
+   `fill_pct = current_fill_level / capacity * 100` guarded against a
+   non-positive capacity.
+8. Four queries start, each with `settings.checkpoint_for(<name>)`:
+   - `bin_events` writes Parquet partitioned by `event_date`.
+   - `dead_letters` writes to `KAFKA_DLQ_TOPIC`; the envelope is built with
+     `to_json(struct(...))` so an unparseable payload cannot corrupt it.
+   - `zone_metrics` aggregates 5-minute windows per zone, append mode, upserted
+     on `(window_start, zone)`.
+   - `bin_state` runs the stateful operator; see the alert-detection breadcrumb.
+9. `sinks.write_batch()` collects each micro-batch to the driver and writes with
+   `execute_values`. Every table has a conflict key, because Spark retries a
+   micro-batch after a failed write and an append would double-count.
+10. `session.streams.awaitAnyTermination()` blocks, so a failed query surfaces
+    instead of leaving the process alive around a dead one.
+
+`src/batch/rollups.py` is a separate entry point over the Parquet history and
+does not participate in this flow.
+
+## Output tables
+
+| Table | Written by | Conflict key | Mode |
+|---|---|---|---|
+| `bin_alerts` | `bin_state` | `(bin_id, alert_type, fired_at)` | do nothing |
+| `bin_state_latest` | `bin_state` | `bin_id` | update |
+| `zone_metrics_5m` | `zone_metrics` | `(window_start, zone)` | update |
+| `zone_hourly_profile` | `batch/rollups.py` | `(zone, hour_of_day)` | update |
+| `zone_daily_trend` | `batch/rollups.py` | `(zone, day)` | update |
+
+`city_kpi` and `zone_leaderboard` are views over those tables. No Spark job
+computes dashboard figures.

--- a/.claude/breadcrumbs/stream-processing/DETAILS.md
+++ b/.claude/breadcrumbs/stream-processing/DETAILS.md
@@ -10,7 +10,10 @@ Paths are relative to `services/stream-processor/`.
    workers as bare `python3` and pandas operators fail on a missing import.
 3. The session sets `RocksDBStateStoreProvider` with changelog checkpointing,
    `spark.sql.shuffle.partitions=12`, and UTC as the session time zone.
-4. `session.read_telemetry()` opens the Kafka source with `startingOffsets`,
+4. `session.read_telemetry()` opens the Kafka source with `startingOffsets`
+   (`earliest`, and only consulted when no checkpoint exists yet — `latest`
+   there loses the readings published while Spark spends tens of seconds
+   building four queries, which is fatal for a bin that falls silent by design),
    `maxOffsetsPerTrigger` and `failOnDataLoss=false`. It returns the raw
    records, not parsed ones, because the dead-letter path needs the original
    bytes.
@@ -18,12 +21,18 @@ Paths are relative to `services/stream-processor/`.
    `schema.telemetry_schema()` — built from `contracts/telemetry-v1.json`, not
    restated in code — and derives `event_time` from the ISO `timestamp` field.
 6. `pipeline.clean.split_valid_and_rejected()` computes two columns:
-   - `rejection_reason` covers only `TRACKING_FIELDS` plus the cross-field check
+   - `rejection_reason` covers only `TRACKING_FIELDS`, the fields the contract
+     says cannot be empty strings, and the cross-field check
      `current_fill_level > capacity`. These make a message unusable.
    - `sensor_fault_reason` covers `REPAIRABLE_FIELDS`. These are nulled by
      `repair()` and the reading is kept, so a bin with one failed sensor stays
      tracked instead of vanishing from monitoring.
-   Bounds for both come from the contract via `schema.range_rules()`.
+   Bounds for both come from the contract via `schema.range_rules()`, which
+   carries whether a minimum is exclusive. That matters for exactly one field:
+   `capacity` is `exclusiveMinimum: 0`, and treating it as inclusive let a
+   zero-capacity message through to divide into a null `fill_pct`, which every
+   fill rule then compared against a threshold — raising in the Python worker
+   and terminating the whole application.
 7. `clean_events()` applies the watermark, then
    `dropDuplicatesWithinWatermark(["bin_id", "event_time"])`, then computes
    `fill_pct = current_fill_level / capacity * 100` guarded against a

--- a/.claude/breadcrumbs/stream-processing/FLOW.md
+++ b/.claude/breadcrumbs/stream-processing/FLOW.md
@@ -1,0 +1,29 @@
+# Stream Processing
+
+Trigger: `python src/main.py` or the `stream_processor` container command.
+
+```text
+apply sql/schema.sql (idempotent)
+  → build SparkSession (RocksDB state store, local[*])
+  → readStream from KAFKA_TOPIC
+  → clean_events: parse → watermark → dedupe → fill_pct → repair
+  → start four queries, each with its own checkpoint:
+      bin_events    → Parquet, partitioned by event_date
+      dead_letters  → KAFKA_DLQ_TOPIC
+      zone_metrics  → zone_metrics_5m      (5-minute windows per zone)
+      bin_state     → bin_alerts, bin_state_latest
+  → awaitAnyTermination
+```
+
+One application, one Kafka read, four queries over it. Cleaning is a plain
+DataFrame transformation shared by all of them, not a hop through storage, so a
+reading is parsed and deduplicated exactly once.
+
+There is **no join against `smart_bins`**. Zone and capacity travel on every
+event, so the stream needs no database read on the ingest path.
+
+Separate checkpoint directories mean one query can be reset without disturbing
+the others. The checkpoints are not a cache — see `DEBUG.md`.
+
+The per-bin rules are documented in [`alert-detection`](../alert-detection/FLOW.md).
+The nightly batch job reads the Parquet this flow writes.

--- a/.claude/breadcrumbs/stream-processing/FLOW.md
+++ b/.claude/breadcrumbs/stream-processing/FLOW.md
@@ -26,4 +26,4 @@ Separate checkpoint directories mean one query can be reset without disturbing
 the others. The checkpoints are not a cache — see `DEBUG.md`.
 
 The per-bin rules are documented in [`alert-detection`](../alert-detection/FLOW.md).
-The nightly batch job reads the Parquet this flow writes.
+The batch rollup job reads the Parquet this flow writes.

--- a/.claude/commands/verify-pipeline.md
+++ b/.claude/commands/verify-pipeline.md
@@ -68,6 +68,18 @@ docker logs stream_processor 2>&1 | grep -E "Started 4 streaming|schema applied"
 
 `Injected faults into N of M bin(s).` must appear, or no detector will fire.
 
+The steps above are a sequence. Starting the simulator before migrating is the
+most common mistake, and it reports itself:
+
+| State | Log line |
+|---|---|
+| Not migrated | `The 'smart_bins' table does not exist.` — exits 1 |
+| Not seeded | `No ACTIVE bins found, so nothing will be published.` |
+| Ready | `Injected faults into N of M bin(s).` |
+
+After that the simulator is silent — per-tick telemetry is DEBUG, so `-f`
+showing nothing means it is working.
+
 Then open the Spark UI at <http://localhost:4040> and check the **Structured
 Streaming** tab lists all four queries with a non-zero input rate. That is the
 fastest confirmation the pipeline is actually consuming, and it is quicker than

--- a/.claude/commands/verify-pipeline.md
+++ b/.claude/commands/verify-pipeline.md
@@ -43,14 +43,25 @@ WATERMARK=2 minutes
 gated by it, not by fill rate. At the 10-minute default the first zone window is
 ~15 minutes away regardless of how fast bins fill.
 
+Note which side each value belongs to. The first four are the simulator's; the
+rest are the stream processor's, and they are the ones the SLA, offline and
+stuck-sensor rules read. Setting only the simulator's half is the easy mistake —
+a bin still takes two hours to breach its SLA no matter how fast it fills.
+`ROLLUP_INTERVAL_SECONDS=120` is worth adding too, or the rollup tables wait
+fifteen minutes.
+
+These same thresholds build `city_kpi` and `zone_leaderboard` when the schema is
+applied, so the processor must be restarted after changing them — not just the
+simulator.
+
 ## Bring it up
 
 ```bash
-docker compose build data_simulator stream_processor
+docker compose build data_simulator stream_processor rollups
 docker compose up -d postgres kafka kafka_init
 docker compose run --rm data_simulator alembic upgrade head
 docker compose run --rm data_simulator python src/seed.py --count 200 --clear
-docker compose up -d data_simulator stream_processor
+docker compose up -d data_simulator stream_processor rollups
 ```
 
 `alembic upgrade head` names each revision it applies. Only the two
@@ -95,14 +106,21 @@ docker exec -it smartbin_postgres psql -U postgres -d smart_city \
   -c "SELECT count(*) FROM zone_metrics_5m;"
 ```
 
-Expect all eleven alert types given enough time. Rough ordering:
+Expect all twelve alert types given enough time. Rough ordering:
 
 | Wait | Appears |
 |---|---|
 | ~30s | `PREDICTED_OVERFLOW`, `SENSOR_FAULT` |
 | 1–3 min | `CRITICAL_FILL`, `OVERFLOW`, `COLLECTED`, `ANOMALY_JUMP`, `SENSOR_STUCK`, `FIRE_RISK` |
-| 3–5 min | `SLA_BREACH`, `LOW_BATTERY` |
+| 3–5 min | `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW`, `LOW_BATTERY` |
 | watermark | `OFFLINE`, `zone_metrics_5m` |
+| `ROLLUP_INTERVAL_SECONDS` | `zone_hourly_profile`, `zone_daily_trend` |
+
+`SENSOR_STUCK`, `FIRE_RISK` and `OFFLINE` have the smallest counts — only a few
+bins carry those faults. `SENSOR_STUCK` comes from `FROZEN` bins, which freeze
+at their seeded level of zero; readings at 100% are deliberately not counted,
+because fill is clamped at capacity and every bin awaiting collection repeats
+the same value.
 
 `total_bins` in `city_kpi` should equal the seeded count. If it is short, some
 bins are being dead-lettered — see `stream-processing/DEBUG.md`.
@@ -122,8 +140,9 @@ docker exec smartbin_kafka kafka-console-consumer \
 # Parquet history, date-partitioned
 docker exec stream_processor ls /data/bin_events
 
-# Nightly rollups
-docker compose exec stream_processor python src/batch/rollups.py
+# Rollups. The `rollups` container already runs this every
+# ROLLUP_INTERVAL_SECONDS; this forces one now rather than waiting.
+docker compose run --rm rollups python src/batch/rollups.py
 docker exec -it smartbin_postgres psql -U postgres -d smart_city \
   -c "SELECT * FROM zone_hourly_profile ORDER BY avg_fill_rate_pct_hour DESC NULLS LAST LIMIT 5;" \
   -c "SELECT * FROM zone_daily_trend;"

--- a/.claude/commands/verify-pipeline.md
+++ b/.claude/commands/verify-pipeline.md
@@ -53,8 +53,8 @@ docker compose run --rm data_simulator python src/seed.py --count 200 --clear
 docker compose up -d data_simulator stream_processor
 ```
 
-Note `alembic upgrade head` prints nothing — `alembic.ini` has no logging
-sections. A successful seed is the confirmation that it ran.
+`alembic upgrade head` names each revision it applies. Only the two
+`Context impl` lines means the database was already at head.
 
 Always `build` before `up`. A stale image is the most common cause of "the
 change did nothing".
@@ -67,6 +67,11 @@ docker logs stream_processor 2>&1 | grep -E "Started 4 streaming|schema applied"
 ```
 
 `Injected faults into N of M bin(s).` must appear, or no detector will fire.
+
+Then open the Spark UI at <http://localhost:4040> and check the **Structured
+Streaming** tab lists all four queries with a non-zero input rate. That is the
+fastest confirmation the pipeline is actually consuming, and it is quicker than
+waiting on any table.
 
 ## Check the outputs
 

--- a/.claude/commands/verify-pipeline.md
+++ b/.claude/commands/verify-pipeline.md
@@ -1,0 +1,133 @@
+---
+description: Bring up the full stack and check every Spark output end to end.
+---
+
+# /verify-pipeline
+
+Runs simulator and stream-processor together against real Postgres and Kafka,
+then checks that every output is populated. Use this after changing anything in
+the processing layer — the unit suites cannot catch image, contract-path,
+checkpoint or topic problems.
+
+## Clean slate
+
+State from a previous run makes a broken pipeline look healthy, and a changed
+`STATE_SCHEMA` makes old checkpoints unreadable:
+
+```bash
+docker compose down -v
+```
+
+`-v` removes the Postgres volume **and** `/data`, which holds the checkpoints
+and Parquet history.
+
+## Demo profile
+
+Without it the first critical bin is ~75 minutes away. Append to
+`services/data-simulator/.env.docker` (gitignored):
+
+```bash
+FILL_RATE_PCT_MIN=1.0
+FILL_RATE_PCT_MAX=6.0
+BATTERY_DRAIN_MIN=1.0
+BATTERY_DRAIN_MAX=3.0
+FAULT_INJECTION_RATE=0.15
+STUCK_READING_COUNT=5
+SLA_CRITICAL_MINUTES=1
+SLA_OVERFLOW_MINUTES=1
+OFFLINE_AFTER_MINUTES=1
+WATERMARK=2 minutes
+```
+
+`WATERMARK` is the one that matters most: windowed output and offline alerts are
+gated by it, not by fill rate. At the 10-minute default the first zone window is
+~15 minutes away regardless of how fast bins fill.
+
+## Bring it up
+
+```bash
+docker compose build data_simulator stream_processor
+docker compose up -d postgres kafka kafka_init
+docker compose run --rm data_simulator alembic upgrade head
+docker compose run --rm data_simulator python src/seed.py --count 200 --clear
+docker compose up -d data_simulator stream_processor
+```
+
+Note `alembic upgrade head` prints nothing — `alembic.ini` has no logging
+sections. A successful seed is the confirmation that it ran.
+
+Always `build` before `up`. A stale image is the most common cause of "the
+change did nothing".
+
+## Check startup
+
+```bash
+docker logs data_simulator   2>&1 | grep -E "Injected|Started .* simulator"
+docker logs stream_processor 2>&1 | grep -E "Started 4 streaming|schema applied"
+```
+
+`Injected faults into N of M bin(s).` must appear, or no detector will fire.
+
+## Check the outputs
+
+```bash
+docker exec -it smartbin_postgres psql -U postgres -d smart_city \
+  -c "SELECT alert_type, severity, count(*) FROM bin_alerts GROUP BY 1,2 ORDER BY 3 DESC;" \
+  -c "SELECT * FROM city_kpi;" \
+  -c "SELECT * FROM zone_leaderboard;" \
+  -c "SELECT count(*) FROM zone_metrics_5m;"
+```
+
+Expect all eleven alert types given enough time. Rough ordering:
+
+| Wait | Appears |
+|---|---|
+| ~30s | `PREDICTED_OVERFLOW`, `SENSOR_FAULT` |
+| 1–3 min | `CRITICAL_FILL`, `OVERFLOW`, `COLLECTED`, `ANOMALY_JUMP`, `SENSOR_STUCK`, `FIRE_RISK` |
+| 3–5 min | `SLA_BREACH`, `LOW_BATTERY` |
+| watermark | `OFFLINE`, `zone_metrics_5m` |
+
+`total_bins` in `city_kpi` should equal the seeded count. If it is short, some
+bins are being dead-lettered — see `stream-processing/DEBUG.md`.
+
+## Check the rest
+
+```bash
+# Partition count - must be 12, not 1
+docker exec smartbin_kafka kafka-topics --bootstrap-server localhost:9092 \
+  --describe --topic smartbin-telemetry-v1 | head -1
+
+# Dead letters carry reason, provenance and the original payload
+docker exec smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-dlq \
+  --from-beginning --max-messages 2 --timeout-ms 30000
+
+# Parquet history, date-partitioned
+docker exec stream_processor ls /data/bin_events
+
+# Nightly rollups
+docker compose exec stream_processor python src/batch/rollups.py
+docker exec -it smartbin_postgres psql -U postgres -d smart_city \
+  -c "SELECT * FROM zone_hourly_profile ORDER BY avg_fill_rate_pct_hour DESC NULLS LAST LIMIT 5;" \
+  -c "SELECT * FROM zone_daily_trend;"
+```
+
+## Cross-check
+
+The streaming rule and the batch window function compute collections
+independently. They should agree within the events in flight:
+
+```bash
+docker exec smartbin_postgres psql -U postgres -d smart_city -tAc \
+  "SELECT (SELECT sum(collections) FROM zone_daily_trend),
+          (SELECT count(*) FROM bin_alerts WHERE alert_type='COLLECTED');"
+```
+
+## Tear down
+
+```bash
+docker compose down          # keeps data
+docker compose down -v       # erases checkpoints and history too
+```
+
+Restore `.env.docker` afterwards if you appended the demo profile.

--- a/.claude/skills/index.md
+++ b/.claude/skills/index.md
@@ -17,7 +17,8 @@ the right entry point before loading the detailed skill.
 |---|---|---|
 | [simulation-engine](simulation-engine/SKILL.md) | Working on `Bin`, `BinSimulator`, `SimulationManager`, the tick loop, or telemetry generation | Subsystem context for the simulation core |
 | [database](database/SKILL.md) | Working on the SQLAlchemy async engine, `SmartBin`/`smart_bins`, schema creation, or seeding | Subsystem context for persistence |
-| [kafka](kafka/SKILL.md) | Working on the `KafkaClient` producer, message format/keys, retries, or broker config | Subsystem context for telemetry publishing |
+| [kafka](kafka/SKILL.md) | Working on the `KafkaClient` producer, message format/keys, retries, topics, or broker config | Subsystem context for telemetry publishing |
+| [spark](spark/SKILL.md) | Working on the stream-processor: Structured Streaming, cleaning and dead letters, windowed aggregates, the stateful operator, checkpoints, or the batch rollups | Subsystem context for stream processing |
 | [config](config/SKILL.md) | Working on `Settings`/`get_settings()`, env vars, `DATABASE_URL`, or `.env` files | Subsystem context for configuration |
 | [testing](testing/SKILL.md) | Writing/running/debugging pytest tests, fixtures, mocks, or docstring hooks | Subsystem context for the test suite |
 | [ci-cd](ci-cd/SKILL.md) | Working on GitHub Actions, branch naming, or PR governance/scope rules | Subsystem context for CI/CD |

--- a/.claude/skills/kafka/SKILL.md
+++ b/.claude/skills/kafka/SKILL.md
@@ -5,9 +5,18 @@ description: >
   connection retries, topics, or KRaft Compose configuration.
 ---
 
-# Kafka Producer
+# Kafka
 
-The data simulator only produces messages. `KafkaClient` owns a module-level
+Two topics, created explicitly by the `kafka_init` Compose service rather than
+auto-created — auto-creation gives one partition, which pins the whole stream to
+a single Spark task.
+
+| Topic | Partitions | Written by | Read by |
+|---|---|---|---|
+| `smartbin-telemetry-v1` | 12 | data-simulator | stream-processor |
+| `smartbin-telemetry-dlq` | 3 | stream-processor | operators |
+
+The data simulator only produces. `KafkaClient` owns a module-level
 `AIOKafkaProducer`; `main.py` starts and stops it, and each `BinSimulator`
 publishes through the shared client.
 
@@ -17,7 +26,11 @@ publishes through the shared client.
 - Key: UTF-8 encoded bin ID.
 - Value: JSON from `Bin.to_payload()`.
 - Fields: bin ID, capacity, fill level, battery level, temperature, latitude,
-  longitude, zone, and UTC timestamp.
+  longitude, zone, and UTC timestamp. The shape is fixed by
+  `contracts/telemetry-v1.json`, which both services assert against; a renamed
+  field otherwise reads as nulls on the consumer with nothing failing.
+- The key matters beyond routing: per-bin ordering across 12 partitions is what
+  the stateful operator depends on. Never repartition an existing topic.
 
 Docker connects to `kafka:29092`; native processes connect to
 `localhost:9092` through their respective environment files.
@@ -27,7 +40,9 @@ Docker connects to `kafka:29092`; native processes connect to
 - Startup retries Kafka connection ten times, three seconds apart, then raises.
 - `send_and_wait` awaits the broker acknowledgement for each message.
 - Sends made before startup or sends that raise are logged and dropped; there
-  is no retry queue or dead-letter topic.
+  is no producer-side retry queue. The dead-letter topic is a *consumer* concern
+  and does not catch these — a message the producer never sent is invisible,
+  which weakens dead-device detection.
 - `aiokafka.cluster` logging is suppressed to CRITICAL.
 - `--from-beginning` replays historical payloads, including records created
   before newer fields existed. Omit it when validating the current schema.

--- a/.claude/skills/simulation-engine/SKILL.md
+++ b/.claude/skills/simulation-engine/SKILL.md
@@ -39,3 +39,27 @@ rounded to two decimals.
   simulator after database changes.
 - Kafka send failures are logged and dropped; there is no retry queue.
 - `NUMBER_OF_BINS` does not control runtime fleet size; active database rows do.
+
+## Fault injection
+
+A share of bins misbehave on purpose (`FAULT_INJECTION_RATE`), because the
+detectors downstream otherwise have nothing to detect. `FAULT_MODES` and
+`assign_fault_modes()` are in `src/simulator/bin_simulator.py`; assignment
+cycles rather than drawing per bin, so a small fleet cannot end up missing a
+mode entirely.
+
+State-level faults are applied in `_simulate()` — the bin really behaves that
+way. Reporting-level faults are applied in `_next_payload()` — the bin is fine,
+the telemetry is not. A broken sensor belongs in the second group.
+
+## Pacing
+
+Fill is a percentage of capacity per tick, so bins of every size cross
+percentage thresholds at the same pace. `COLLECTION_THRESHOLD_PCT` must stay
+above the consumer's critical threshold of 80, or bins are emptied on the way up
+and never once register as critical.
+
+Defaults are paced for a real bin (~75 minutes to critical). `.env.local.example`
+carries a demo profile that compresses it to minutes.
+
+See the `fault-injection` breadcrumb for the full trace.

--- a/.claude/skills/spark/SKILL.md
+++ b/.claude/skills/spark/SKILL.md
@@ -55,6 +55,18 @@ One application, four queries, one separate batch entry point.
   would reject the readings a rule exists to catch — a bin above 70 °C is
   exactly what fire risk looks for.
 
+## The Spark UI
+
+<http://localhost:4040>, published from the container. The **Structured
+Streaming** tab is the one that matters: input and processing rate, batch
+duration, watermark position and state store size per query, none of which the
+logs report. Open it before guessing why a query looks stalled.
+
+The batch job binds <http://localhost:4041> instead, because it runs alongside
+the streaming application. Both are set explicitly with
+`spark.ui.portMaxRetries=0`, so a bind failure is loud rather than a silent move
+to another port.
+
 ## Testing
 
 The rules are plain Python over dictionaries and pandas, so most of the suite

--- a/.claude/skills/spark/SKILL.md
+++ b/.claude/skills/spark/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: spark
+description: >
+  Load for the stream-processor service, PySpark Structured Streaming,
+  the cleaning and dead-letter path, windowed zone aggregates, the stateful
+  per-bin operator, checkpoints, or the nightly batch rollups.
+---
+
+# Stream Processor
+
+`services/stream-processor/` reads `smartbin-telemetry-v1` with Spark
+Structured Streaming and writes alerts, per-bin state and zone aggregates to
+PostgreSQL, plus a Parquet event history.
+
+One application, four queries, one separate batch entry point.
+
+| Module | Role |
+|---|---|
+| `src/schema.py` | Builds the Spark schema from `contracts/telemetry-v1.json` |
+| `src/session.py` | SparkSession and the Kafka source |
+| `src/pipeline/clean.py` | Query 1 — parse, validate, repair, deduplicate |
+| `src/pipeline/zone_metrics.py` | Query 3 — 5-minute windows per zone |
+| `src/pipeline/bin_state.py` | Query 2 — the stateful operator, eleven alert types |
+| `src/batch/rollups.py` | Nightly job over the Parquet history |
+| `src/sinks.py` | psycopg2 writes with conflict keys |
+| `sql/schema.sql` | Output tables and the dashboard views |
+
+## Non-obvious constraints
+
+- **Python 3.11, not 3.12.** PySpark 3.5 supports up to 3.11; on 3.12 the pandas
+  operator path fails importing `distutils`. The image and CI pin it.
+- **Spark 3.5 exactly.** `dropDuplicatesWithinWatermark` needs ≥ 3.5,
+  `applyInPandasWithState` needs ≥ 3.4. The Kafka connector jars are baked into
+  the image and must match the Spark version.
+- **Java 17, not 21.** Spark 3.5 supports 8, 11 and 17. The base image is pinned
+  to bookworm because trixie dropped the 17 packages.
+- **`ensure_worker_interpreter()` must run before any session is built.** Spark
+  launches workers as bare `python3` otherwise, and they start without pandas.
+- **No JDBC anywhere.** Writes go through psycopg2, because Spark's JDBC writer
+  can only append or overwrite and every table here needs an upsert. That also
+  keeps the Kafka connector as the only jars in the image.
+
+## Rules that shaped the design
+
+- **Every write is idempotent.** Spark retries a micro-batch after a failed
+  write. Appending would double-count on every retry, so each table has a
+  conflict key.
+- **No join against `smart_bins`.** Zone and capacity travel on every event.
+- **Validation is field-level, not message-level.** A field the pipeline needs
+  (`TRACKING_FIELDS`) is fatal and the message is dead-lettered. A sensor that
+  can fail alone (`REPAIRABLE_FIELDS`) is nulled and the reading kept, so a bin
+  with a dead thermometer stays visible rather than disappearing from every
+  figure and never arming an offline timeout.
+- **Bounds come from the contract**, never restated in code. Too narrow a range
+  would reject the readings a rule exists to catch — a bin above 70 °C is
+  exactly what fire risk looks for.
+
+## Testing
+
+The rules are plain Python over dictionaries and pandas, so most of the suite
+runs without a cluster in under a second. Only what pandas cannot reach —
+deduplication, windowing, the state store round-trip — uses a real session.
+
+```bash
+cd services/stream-processor
+.venv/bin/python -m pytest -q
+.venv/bin/python -m pytest tests/test_bin_state.py -k fire -v
+```
+
+## Checkpoints
+
+`/data/checkpoints/<query>` holds every SLA clock, last-seen timestamp and
+deduplication key. It is not a cache — deleting it erases the pipeline's memory
+of the whole fleet. Changing `STATE_SCHEMA` makes the `bin_state` checkpoint
+unreadable and it must be deleted.
+
+See the `stream-processing` and `alert-detection` breadcrumbs for full traces.

--- a/.claude/skills/spark/SKILL.md
+++ b/.claude/skills/spark/SKILL.md
@@ -3,7 +3,7 @@ name: spark
 description: >
   Load for the stream-processor service, PySpark Structured Streaming,
   the cleaning and dead-letter path, windowed zone aggregates, the stateful
-  per-bin operator, checkpoints, or the nightly batch rollups.
+  per-bin operator, checkpoints, or the batch rollups.
 ---
 
 # Stream Processor
@@ -12,7 +12,8 @@ description: >
 Structured Streaming and writes alerts, per-bin state and zone aggregates to
 PostgreSQL, plus a Parquet event history.
 
-One application, four queries, one separate batch entry point.
+One application, four queries, plus a batch entry point that runs in its own
+`rollups` container on a timer.
 
 | Module | Role |
 |---|---|
@@ -20,8 +21,8 @@ One application, four queries, one separate batch entry point.
 | `src/session.py` | SparkSession and the Kafka source |
 | `src/pipeline/clean.py` | Query 1 — parse, validate, repair, deduplicate |
 | `src/pipeline/zone_metrics.py` | Query 3 — 5-minute windows per zone |
-| `src/pipeline/bin_state.py` | Query 2 — the stateful operator, eleven alert types |
-| `src/batch/rollups.py` | Nightly job over the Parquet history |
+| `src/pipeline/bin_state.py` | Query 2 — the stateful operator, twelve alert types |
+| `src/batch/rollups.py` | Scheduled batch job over the Parquet history |
 | `src/sinks.py` | psycopg2 writes with conflict keys |
 | `sql/schema.sql` | Output tables and the dashboard views |
 
@@ -53,7 +54,22 @@ One application, four queries, one separate batch entry point.
   figure and never arming an offline timeout.
 - **Bounds come from the contract**, never restated in code. Too narrow a range
   would reject the readings a rule exists to catch — a bin above 70 °C is
-  exactly what fire risk looks for.
+  exactly what fire risk looks for. Exclusivity is carried through, not
+  flattened: `capacity` is `exclusiveMinimum: 0`, and a zero admitted there
+  divides to a null `fill_pct` that every fill rule then compares against a
+  threshold — which raises in the worker and stops the application.
+- **Fire-once flags clear on a collection and nothing else.** Clearing them
+  whenever the level falls back under the threshold lets a bin oscillating
+  around 80% re-alert on every crossing and restart its SLA clock each time.
+- **Alert types are the database key.** `bin_alerts` is keyed on
+  `(bin_id, alert_type, fired_at)`, so two conditions that can come due on the
+  same reading need distinct types — which is why the SLA breach is
+  `SLA_BREACH_CRITICAL` and `SLA_BREACH_OVERFLOW` rather than one type with a
+  label in `detail`.
+- **The dashboard views are built from the same settings as the rules.**
+  `sinks.schema_sql()` fills the thresholds into `sql/schema.sql`, so
+  `city_kpi` cannot disagree with the alerts — and `sql/schema.sql` cannot be
+  run through `psql` directly, because it carries placeholders.
 
 ## The Spark UI
 
@@ -63,7 +79,7 @@ duration, watermark position and state store size per query, none of which the
 logs report. Open it before guessing why a query looks stalled.
 
 The batch job binds <http://localhost:4041> instead, because it runs alongside
-the streaming application. Both are set explicitly with
+the streaming application — only for the length of each run. Both are set explicitly with
 `spark.ui.portMaxRetries=0`, so a bind failure is loud rather than a silent move
 to another port.
 
@@ -78,6 +94,19 @@ cd services/stream-processor
 .venv/bin/python -m pytest -q
 .venv/bin/python -m pytest tests/test_bin_state.py -k fire -v
 ```
+
+## Shutdown
+
+`main.run()` waits on `awaitAnyTermination` **with a timeout** and loops. That is
+not a style choice: Python runs a signal handler between bytecodes, so while the
+main thread is inside an unbounded py4j call SIGTERM is never noticed and Docker
+kills the container. The queries are then stopped by name so each finishes its
+micro-batch and commits offsets, and the service carries `stop_grace_period: 60s`
+because ten seconds is not enough for four of them.
+
+A killed container loses nothing — checkpoints and idempotent writes cover it —
+but it reports as exit 137, which is the wrong thing to leave in
+`docker compose ps` for an ordinary stop.
 
 ## Checkpoints
 

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -28,3 +28,26 @@ docker build --target test -t smart-city-data-simulator-test .
 
 CI installs both requirements files and runs `pytest -v`. Adding a required
 setting also requires a dummy value in `tests/conftest.py`.
+
+## Two services, two suites
+
+`services/data-simulator/` runs on Python 3.12. `services/stream-processor/`
+runs on **3.11** — PySpark 3.5 does not support 3.12 and its pandas operators
+fail at run time importing `distutils`. CI runs one job per service with its own
+Python version.
+
+```bash
+cd services/data-simulator   && .venv/bin/python -m pytest -q
+cd services/stream-processor && .venv/bin/python -m pytest -q
+```
+
+The stream-processor suite starts a real local SparkSession, shared session-wide
+by the `spark` fixture. Prefer testing transformations as plain DataFrame
+functions on batch data — they behave identically on a stream — and reserve the
+streaming fixture for what batch cannot reach: watermarks, deduplication,
+windowing, and the state store round-trip.
+
+The per-bin rules are plain Python over dictionaries with a `FakeGroupState`
+stand-in, so they need no cluster at all. Every rule has both a positive case
+and a must-not-fire case; a rule that fires on everything and a correct one look
+identical if only the first is tested.

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -10,8 +10,18 @@ permissions:
 
 jobs:
   pytest:
-    name: Run Pytests
+    name: Run Pytests (${{ matrix.service }})
     runs-on: ubuntu-latest
+
+    # One job per service. This was hardcoded to data-simulator, which meant a
+    # new service could be added with a full test suite and CI would never run
+    # a single one of its tests. Add new services here.
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - data-simulator
+          - stream-processor
 
     services:
       postgres:
@@ -30,7 +40,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: services/data-simulator
+        working-directory: services/${{ matrix.service }}
 
     steps:
       - name: Checkout repository
@@ -42,8 +52,8 @@ jobs:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: |
-            services/data-simulator/requirements.txt
-            services/data-simulator/requirements-dev.txt
+            services/${{ matrix.service }}/requirements.txt
+            services/${{ matrix.service }}/requirements-dev.txt
 
       - name: Upgrade pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/pr-pytest.yml
+++ b/.github/workflows/pr-pytest.yml
@@ -19,9 +19,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service:
-          - data-simulator
-          - stream-processor
+        include:
+          - service: data-simulator
+            python-version: "3.12"
+            needs-java: false
+          # PySpark 3.5 supports Python up to 3.11. On 3.12 its pandas operators
+          # fail at run time importing distutils, removed in that version - so
+          # this is pinned rather than kept in step with the other service.
+          - service: stream-processor
+            python-version: "3.11"
+            needs-java: true
 
     services:
       postgres:
@@ -46,10 +53,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
+      # Spark runs on the JVM even when driven from Python, and local mode
+      # still starts one in-process.
+      - name: Set up Java 17
+        if: matrix.needs-java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: |
             services/${{ matrix.service }}/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ event.json
 
 # generated reports
 writeup/
+
+# Stream processor local state
+services/stream-processor/logs/

--- a/README.md
+++ b/README.md
@@ -220,6 +220,23 @@ window lands. Lower `WATERMARK` for a faster demo.
 
 ---
 
+## Order matters
+
+The four steps above are a sequence, not a menu. Starting the simulator against
+a database that has not been migrated is the single most common mistake, so both
+bad states say what to do rather than failing obscurely:
+
+| State | What you get |
+|---|---|
+| Not migrated | `The 'smart_bins' table does not exist.` plus the two commands to run. Exits 1, cleanly. |
+| Migrated, not seeded | `No ACTIVE bins found, so nothing will be published.` plus the seed command. Keeps running. |
+| Migrated and seeded | `Injected faults into N of M bin(s).` then `Started M simulator(s).` |
+
+If you see a raw SQLAlchemy traceback instead of the first message, the image is
+stale — `docker compose build data_simulator`.
+
+---
+
 ## Verification & Debugging
 
 **View Simulator Logs:**
@@ -227,6 +244,14 @@ window lands. Lower `WATERMARK` for a faster demo.
 ```bash
 docker logs data_simulator -f
 ```
+
+A healthy simulator is **silent after startup**. Per-tick telemetry is logged at
+DEBUG, so `-f` showing nothing means it is working, not stalled. To watch actual
+activity, consume from Kafka (below) or query `bin_state_latest`. On a native
+process, `kill -USR1 <pid>` toggles debug logging.
+
+The last line on a normal shutdown is `Shutdown complete`, with no warnings and
+exit code 0.
 
 **Spark UI:** <http://localhost:4040> — the Structured Streaming tab shows what
 each query is actually doing.
@@ -248,6 +273,13 @@ docker exec smartbin_kafka kafka-console-consumer \
 
 Do not add `--from-beginning` when validating the current payload schema; it
 also replays historical records created before newer fields existed.
+
+**Confirm both services came up:**
+
+```bash
+docker logs data_simulator   2>&1 | grep -E "Injected|Started .* simulator"
+docker logs stream_processor 2>&1 | grep -E "Started 4 streaming|UI on port"
+```
 
 **Verify the processing layer:**
 

--- a/README.md
+++ b/README.md
@@ -128,28 +128,50 @@ One Spark application, four queries, one nightly batch job.
 | `bin_events` | Parquet, partitioned by date | The history the nightly job reads |
 | `dead_letters` | `smartbin-telemetry-dlq` | Messages that could not be parsed or believed |
 | `zone_metrics` | `zone_metrics_5m` | Per-zone rollups, at every grain, by SQL |
-| `bin_state` | `bin_alerts`, `bin_state_latest` | Ten alert types from one per-bin state read |
+| `bin_state` | `bin_alerts`, `bin_state_latest` | Eleven alert types from one per-bin state read |
 | `batch/rollups.py` | `zone_hourly_profile`, `zone_daily_trend` | Peak hours and long-range trends |
-
-Alert types: `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `FIRE_RISK`,
-`LOW_BATTERY`, `OFFLINE`, `COLLECTED`, `ANOMALY_JUMP`, `SENSOR_STUCK`,
-`SLA_BREACH`.
 
 Dashboard figures are the `city_kpi` and `zone_leaderboard` views over those
 tables — no Spark job of their own.
+
+Alert types: `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `FIRE_RISK`,
+`LOW_BATTERY`, `OFFLINE`, `COLLECTED`, `ANOMALY_JUMP`, `SENSOR_STUCK`,
+`SENSOR_FAULT`, `SLA_BREACH`.
+
+### One bad sensor does not lose the bin
+
+Validation is field-level, not message-level. A field the pipeline needs — bin,
+zone, capacity, fill level, timestamp — is fatal and the message is
+dead-lettered whole. A sensor that can fail on its own — temperature, battery,
+coordinates — is **nulled and the reading kept**, and the bin raises
+`SENSOR_FAULT` naming what failed.
+
+That distinction matters more than it looks. Rejecting the whole message for an
+impossible temperature meant the bin never reached the state store, so it
+vanished from every dashboard figure *and* never armed an offline timeout — a
+bin publishing every five seconds became completely invisible, with the DLQ as
+its only trace. The loudest possible sensor failure produced the quietest
+possible outcome.
+
+Nulled rather than clamped, because clamping 150 °C to 120 °C invents a
+plausible number no sensor reported and then averages it into the zone
+temperature as though it were real.
+
+`city_kpi.faulty_sensor_bins` counts these. They stay in every other figure too,
+which is the point.
 
 ### Fault injection
 
 A share of bins (`FAULT_INJECTION_RATE`, default 12%) misbehave on purpose, so
 every detector has something to detect. Without them the offline, stuck-sensor,
-duplicate, impossible-value, fire-risk and SLA rules can be written but never
+duplicate, sensor-fault, fire-risk and SLA rules can be written but never
 observed working.
 
 | Mode | Behaviour | Proves |
 |---|---|---|
 | `SILENT` | reports for a while, then stops | `OFFLINE` |
 | `FROZEN` | repeats one reading forever | `SENSOR_STUCK` |
-| `SPIKE` | reports 150 °C | dead-lettering |
+| `SPIKE` | alternates an impossible temperature and an impossible fill level | `SENSOR_FAULT` and dead-lettering |
 | `DUPLICATE` | re-sends the previous event verbatim | deduplication |
 | `HOT` | runs hot in proportion to how full it is | `FIRE_RISK` |
 | `JUMP` | one large but legal fill jump | `ANOMALY_JUMP` |
@@ -225,12 +247,19 @@ docker exec stream_processor ls /data/bin_events
 docker compose exec stream_processor python src/batch/rollups.py
 ```
 
-With fault injection on, all ten alert types should appear in that first query.
+With fault injection on, all eleven alert types should appear in that first
+query, and `city_kpi.total_bins` should equal the number you seeded. If it is
+short, some bins are being dead-lettered — compare the DLQ bin IDs against
+`bin_state_latest`.
 
 > `/data` on the stream processor is a named volume holding the checkpoints. It
 > is not a cache: it holds every SLA clock, last-seen timestamp and
 > deduplication key in the fleet. `docker compose down -v` erases the
 > pipeline's memory, not its scratch space.
+>
+> Changing `STATE_SCHEMA` in `bin_state.py` makes existing checkpoints
+> unreadable — Spark cannot restore state written under a different schema.
+> Delete `/data/checkpoints/bin_state` after any such change.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ docker compose run --rm data_simulator alembic downgrade 9b7a1e20a036
 ### 4. Start the Services
 
 ```bash
-docker compose up -d --force-recreate data_simulator stream_processor
+docker compose up -d --force-recreate data_simulator stream_processor rollups
 ```
 
 The stream processor applies `services/stream-processor/sql/schema.sql` on
@@ -133,8 +133,9 @@ place to look when a query seems stalled. It reports per query: input rate,
 processing rate, batch duration, watermark position and state store size. None
 of that appears in the logs.
 
-The nightly batch job runs alongside the streaming application and gets its own
-port, **<http://localhost:4041>**, for as long as it runs. Both are bound
+The rollup job runs in its own container alongside the streaming application
+and gets its own port, **<http://localhost:4041>**, for as long as each run
+lasts. Both are bound
 explicitly (`SPARK_UI_PORT`, `SPARK_BATCH_UI_PORT`) rather than left to Spark's
 retry, so the address never moves.
 
@@ -142,14 +143,14 @@ retry, so the address never moves.
 
 ## The Processing Layer
 
-One Spark application, four queries, one nightly batch job.
+One Spark application with four streaming queries, plus a batch job on a timer.
 
 | Query | Writes | Answers |
 |---|---|---|
-| `bin_events` | Parquet, partitioned by date | The history the nightly job reads |
+| `bin_events` | Parquet, partitioned by date | The history the batch job reads |
 | `dead_letters` | `smartbin-telemetry-dlq` | Messages that could not be parsed or believed |
 | `zone_metrics` | `zone_metrics_5m` | Per-zone rollups, at every grain, by SQL |
-| `bin_state` | `bin_alerts`, `bin_state_latest` | Eleven alert types from one per-bin state read |
+| `bin_state` | `bin_alerts`, `bin_state_latest` | Twelve alert types from one per-bin state read |
 | `batch/rollups.py` | `zone_hourly_profile`, `zone_daily_trend` | Peak hours and long-range trends |
 
 Dashboard figures are the `city_kpi` and `zone_leaderboard` views over those
@@ -157,7 +158,17 @@ tables — no Spark job of their own.
 
 Alert types: `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `FIRE_RISK`,
 `LOW_BATTERY`, `OFFLINE`, `COLLECTED`, `ANOMALY_JUMP`, `SENSOR_STUCK`,
-`SENSOR_FAULT`, `SLA_BREACH`.
+`SENSOR_FAULT`, `SLA_BREACH_CRITICAL`, `SLA_BREACH_OVERFLOW`.
+
+The two SLA breaches are separate types rather than one with a label. Both
+clocks can come due on the same reading, and `bin_alerts` is keyed on
+`(bin_id, alert_type, fired_at)` — under a shared type the second row collided
+with the first and was dropped on insert.
+
+The thresholds these rules use are also what builds `city_kpi` and
+`zone_leaderboard`, filled in when the schema is applied. Changing a threshold
+therefore needs the stream processor restarted, and the dashboard cannot drift
+away from the alerts.
 
 ### One bad sensor does not lose the bin
 
@@ -179,7 +190,15 @@ plausible number no sensor reported and then averages it into the zone
 temperature as though it were real.
 
 `city_kpi.faulty_sensor_bins` counts these. They stay in every other figure too,
-which is the point.
+which is the point. A second sensor failing later raises its own alert — the
+pipeline remembers *which* sensors it has reported, not merely that it reported
+one.
+
+A message whose `capacity` is zero is fatal, not repairable. It divides to a
+null fill percentage, and every fill rule compares that number against a
+threshold — which raises in the Spark worker and stops the application. The
+contract declares `exclusiveMinimum: 0` and validation enforces the
+exclusivity.
 
 ### Fault injection
 
@@ -196,7 +215,7 @@ observed working.
 | `DUPLICATE` | re-sends the previous event verbatim | deduplication |
 | `HOT` | runs hot in proportion to how full it is | `FIRE_RISK` |
 | `JUMP` | one large but legal fill jump | `ANOMALY_JUMP` |
-| `UNCOLLECTED` | the truck never comes | `SLA_BREACH` |
+| `UNCOLLECTED` | the truck never comes | `SLA_BREACH_CRITICAL` / `SLA_BREACH_OVERFLOW` |
 
 Modes are assigned by cycling rather than drawing per bin, so a small fleet
 cannot end up with no hot bin and therefore no fire alert anywhere in the run.
@@ -299,11 +318,12 @@ docker exec smartbin_kafka kafka-console-consumer \
 # The Parquet history, partitioned by date
 docker exec stream_processor ls /data/bin_events
 
-# The nightly rollups, on demand
-docker compose exec stream_processor python src/batch/rollups.py
+# The rollups. The `rollups` container runs this every
+# ROLLUP_INTERVAL_SECONDS (default 900); this is only to see one immediately.
+docker compose run --rm rollups python src/batch/rollups.py
 ```
 
-With fault injection on, all eleven alert types should appear in that first
+With fault injection on, all twelve alert types should appear in that first
 query, and `city_kpi.total_bins` should equal the number you seeded. If it is
 short, some bins are being dead-lettered — compare the DLQ bin IDs against
 `bin_state_latest`.
@@ -322,7 +342,7 @@ short, some bins are being dead-lettered — compare the DLQ bin IDs against
 The data simulator has pytest coverage for its models, simulation behavior,
 fault injection, configuration, migration chain, database mapping, lifecycle,
 and Kafka client. The stream processor covers the payload contract, the
-validation and dead-letter rules, all ten detection rules, the batch rollups,
+validation and dead-letter rules, all twelve detection rules, the batch rollups,
 and the streaming behaviour that batch tests cannot reach — deduplication and
 the stateful operator running under a real Spark session.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
 # Smart City Trash Bin Monitor - BinForge 🏙️
 
-Data Simulator is the data generation service for the Smart City Trash Bin
-Monitor. It runs one asynchronous simulation per active bin and publishes fill,
-battery, temperature, location, zone, and timestamp telemetry to Apache Kafka.
+Two services. The **Data Simulator** runs one asynchronous simulation per active
+bin and publishes fill, battery, temperature, location, zone and timestamp
+telemetry to Apache Kafka. The **Stream Processor** reads that topic with Spark
+Structured Streaming and turns it into alerts, per-bin state and zone
+aggregates in PostgreSQL, plus a Parquet event history.
 
 ## Architecture
 
 - **Simulator**: Python 3.12 (AsyncIO)
+- **Stream Processor**: Python 3.11, PySpark 3.5 (see note below)
 - **Database**: PostgreSQL 15
 - **Message Broker**: Apache Kafka (KRaft mode)
+
+```
+data-simulator ──▶ smartbin-telemetry-v1 ──▶ stream-processor ──▶ PostgreSQL
+                                                    │                Parquet
+                                                    └──▶ smartbin-telemetry-dlq
+```
+
+Both services read the same payload contract, `contracts/telemetry-v1.json`.
+The producer asserts its payload against it and the consumer builds its Spark
+schema from it, so a renamed field fails a test instead of silently reading as
+nulls on the consumer side.
+
+> **Python 3.11 for the stream processor.** PySpark 3.5 supports Python up to
+> 3.11. On 3.12 its pandas operators fail at run time importing `distutils`,
+> which that version removed. The image and CI pin 3.11; the simulator stays on
+> 3.12.
 
 ## Quick Start (Docker)
 
@@ -26,12 +45,28 @@ _(Note: If you plan to run the Python script natively instead of via Docker, cre
 
 ### 2. Start Infrastructure
 
-Start PostgreSQL and Kafka, then build the simulator image:
+Start PostgreSQL and Kafka, create the topics, then build the images:
 
 ```bash
-docker compose up -d postgres kafka
-docker compose build data_simulator
+docker compose up -d postgres kafka kafka_init
+docker compose build data_simulator stream_processor
 ```
+
+`kafka_init` creates `smartbin-telemetry-v1` with 12 partitions and
+`smartbin-telemetry-dlq` with 3, and prints what it created. Twelve partitions
+is what lets Spark spread the load; auto-creation would give one, pinning the
+whole stream to a single task.
+
+> If the topic already exists with the wrong partition count, `kafka_init`
+> leaves it alone — adding partitions later would change which partition a
+> bin's key hashes to and break the per-bin ordering the stateful query relies
+> on. Delete it and let `kafka_init` recreate it:
+>
+> ```bash
+> docker exec smartbin_kafka kafka-topics --bootstrap-server localhost:9092 \
+>   --delete --topic smartbin-telemetry-v1
+> docker compose up kafka_init
+> ```
 
 _(The simulator will not emit telemetry until the database is migrated and seeded.)_
 
@@ -71,13 +106,74 @@ To roll back only the zone migration on a disposable database:
 docker compose run --rm data_simulator alembic downgrade 9b7a1e20a036
 ```
 
-### 4. Recreate Simulator
-
-Recreate the simulator to pick up the rebuilt image and seeded data:
+### 4. Start the Services
 
 ```bash
-docker compose up -d --force-recreate data_simulator
+docker compose up -d --force-recreate data_simulator stream_processor
 ```
+
+The stream processor applies `services/stream-processor/sql/schema.sql` on
+startup — it is idempotent, so restarting never destroys accumulated history —
+and then starts four streaming queries: `bin_events`, `dead_letters`,
+`zone_metrics` and `bin_state`.
+
+---
+
+## The Processing Layer
+
+One Spark application, four queries, one nightly batch job.
+
+| Query | Writes | Answers |
+|---|---|---|
+| `bin_events` | Parquet, partitioned by date | The history the nightly job reads |
+| `dead_letters` | `smartbin-telemetry-dlq` | Messages that could not be parsed or believed |
+| `zone_metrics` | `zone_metrics_5m` | Per-zone rollups, at every grain, by SQL |
+| `bin_state` | `bin_alerts`, `bin_state_latest` | Ten alert types from one per-bin state read |
+| `batch/rollups.py` | `zone_hourly_profile`, `zone_daily_trend` | Peak hours and long-range trends |
+
+Alert types: `CRITICAL_FILL`, `OVERFLOW`, `PREDICTED_OVERFLOW`, `FIRE_RISK`,
+`LOW_BATTERY`, `OFFLINE`, `COLLECTED`, `ANOMALY_JUMP`, `SENSOR_STUCK`,
+`SLA_BREACH`.
+
+Dashboard figures are the `city_kpi` and `zone_leaderboard` views over those
+tables — no Spark job of their own.
+
+### Fault injection
+
+A share of bins (`FAULT_INJECTION_RATE`, default 12%) misbehave on purpose, so
+every detector has something to detect. Without them the offline, stuck-sensor,
+duplicate, impossible-value, fire-risk and SLA rules can be written but never
+observed working.
+
+| Mode | Behaviour | Proves |
+|---|---|---|
+| `SILENT` | reports for a while, then stops | `OFFLINE` |
+| `FROZEN` | repeats one reading forever | `SENSOR_STUCK` |
+| `SPIKE` | reports 150 °C | dead-lettering |
+| `DUPLICATE` | re-sends the previous event verbatim | deduplication |
+| `HOT` | runs hot in proportion to how full it is | `FIRE_RISK` |
+| `JUMP` | one large but legal fill jump | `ANOMALY_JUMP` |
+| `UNCOLLECTED` | the truck never comes | `SLA_BREACH` |
+
+Modes are assigned by cycling rather than drawing per bin, so a small fleet
+cannot end up with no hot bin and therefore no fire alert anywhere in the run.
+
+### Pacing, and the demo profile
+
+The defaults are paced for a real bin: about an hour and a quarter to a critical
+level, two hours to a battery alert. That is deliberate — the SLA rules allow
+two hours to collect a critical bin, and at a faster rate a bin overflows dozens
+of times before one SLA clock expires.
+
+To see everything in minutes instead, uncomment the demo profile in
+`.env.local.example` and copy those values into `.env.docker`. The fire-risk
+temperature ramp scales with fill level, so it needs no adjusting.
+
+Two things stay slow regardless, and both are the watermark rather than the
+pacing: `zone_metrics_5m` rows only appear once the watermark passes the end of
+a window, and `OFFLINE` only fires once it passes a bin's timeout. With the
+default `WATERMARK` of 10 minutes, expect roughly 15 minutes before the first
+window lands. Lower `WATERMARK` for a faster demo.
 
 ---
 
@@ -107,30 +203,74 @@ docker exec smartbin_kafka kafka-console-consumer \
 Do not add `--from-beginning` when validating the current payload schema; it
 also replays historical records created before newer fields existed.
 
+**Verify the processing layer:**
+
+```bash
+# What fired, and how much of it
+docker exec -it smartbin_postgres psql -U postgres -d smart_city \
+  -c "SELECT alert_type, severity, count(*) FROM bin_alerts GROUP BY 1,2 ORDER BY 3 DESC;" \
+  -c "SELECT * FROM city_kpi;" \
+  -c "SELECT * FROM zone_leaderboard;" \
+  -c "SELECT * FROM zone_metrics_5m ORDER BY window_start DESC LIMIT 5;"
+
+# Messages Spark refused, with the reason and the original payload
+docker exec smartbin_kafka kafka-console-consumer \
+  --bootstrap-server localhost:9092 --topic smartbin-telemetry-dlq \
+  --from-beginning --max-messages 2 --timeout-ms 30000
+
+# The Parquet history, partitioned by date
+docker exec stream_processor ls /data/bin_events
+
+# The nightly rollups, on demand
+docker compose exec stream_processor python src/batch/rollups.py
+```
+
+With fault injection on, all ten alert types should appear in that first query.
+
+> `/data` on the stream processor is a named volume holding the checkpoints. It
+> is not a cache: it holds every SLA clock, last-seen timestamp and
+> deduplication key in the fleet. `docker compose down -v` erases the
+> pipeline's memory, not its scratch space.
+
 ## Testing
 
 The data simulator has pytest coverage for its models, simulation behavior,
-configuration, migration chain, database mapping, lifecycle, and Kafka client.
+fault injection, configuration, migration chain, database mapping, lifecycle,
+and Kafka client. The stream processor covers the payload contract, the
+validation and dead-letter rules, all ten detection rules, the batch rollups,
+and the streaming behaviour that batch tests cannot reach — deduplication and
+the stateful operator running under a real Spark session.
+
+The detection rules are plain Python over a dictionary, so they run without a
+cluster in under a second. Each is tested both for firing when it should and
+staying quiet when it should not; a rule that fires on everything looks
+identical to a correct one if only the first case is checked.
 
 Run tests locally:
 
 ```bash
-cd services/data-simulator
-pytest -v
+cd services/data-simulator   && pytest -v
+cd services/stream-processor && pytest -v
 ```
 
-Or reproduce the Docker test stage:
+Or reproduce the Docker test stages:
 
 ```bash
 docker build --target test \
   -t smart-city-data-simulator-test services/data-simulator
+docker build --target test -f services/stream-processor/Dockerfile \
+  -t smart-city-stream-processor-test .
 ```
+
+_(The stream processor builds from the repository root so the shared contract is
+in the build context.)_
 
 ## CI/CD Pipeline
 
 GitHub Actions detects supported branch prefixes, enforces file scope for
-`feature/` branches, and runs the data-simulator pytest suite on pull requests
-to `develop`.
+`feature/` branches, and runs one pytest job per service on pull requests to
+`develop`. Each service in the matrix carries its own Python version, since the
+two do not agree on one.
 
 **Feature Policy:**
 When creating a feature branch, you must name it `feature/<service>/<task>` (e.g. `feature/data-simulator/add-tests`).

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ docker compose run --rm data_simulator alembic upgrade head
 docker compose run --rm data_simulator python src/seed.py --count 50
 ```
 
+The upgrade names every revision it applies:
+
+```text
+INFO  [alembic.runtime.migration] Running upgrade  -> 9b7a1e20a036, Create the initial smart_bins schema.
+INFO  [alembic.runtime.migration] Running upgrade 9b7a1e20a036 -> 0002_add_zone, Add zone to smart_bins and backfill existing rows.
+```
+
+Only the two `Context impl` lines means the database was already at head.
+
 List migration history and mark the database's current revision:
 
 ```bash
@@ -116,6 +125,18 @@ The stream processor applies `services/stream-processor/sql/schema.sql` on
 startup — it is idempotent, so restarting never destroys accumulated history —
 and then starts four streaming queries: `bin_events`, `dead_letters`,
 `zone_metrics` and `bin_state`.
+
+### The Spark UI
+
+**<http://localhost:4040>** — and its **Structured Streaming** tab is the first
+place to look when a query seems stalled. It reports per query: input rate,
+processing rate, batch duration, watermark position and state store size. None
+of that appears in the logs.
+
+The nightly batch job runs alongside the streaming application and gets its own
+port, **<http://localhost:4041>**, for as long as it runs. Both are bound
+explicitly (`SPARK_UI_PORT`, `SPARK_BATCH_UI_PORT`) rather than left to Spark's
+retry, so the address never moves.
 
 ---
 
@@ -206,6 +227,9 @@ window lands. Lower `WATERMARK` for a faster demo.
 ```bash
 docker logs data_simulator -f
 ```
+
+**Spark UI:** <http://localhost:4040> — the Structured Streaming tab shows what
+each query is actually doing.
 
 **Verify Postgres Data:**
 

--- a/contracts/telemetry-v1.json
+++ b/contracts/telemetry-v1.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://smart-city-trash-bin-monitor/contracts/telemetry-v1.json",
+  "title": "Smart bin telemetry, version 1",
+  "description": "The message body published to the Kafka topic smartbin-telemetry-v1. The producer is services/data-simulator (Bin.to_payload). The consumer is services/stream-processor, which builds its Spark StructType from this file. Adding an optional field is backward compatible; renaming or removing one is not, and becomes smartbin-telemetry-v2.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "bin_id",
+    "capacity",
+    "current_fill_level",
+    "battery_level",
+    "temperature",
+    "latitude",
+    "longitude",
+    "zone",
+    "timestamp"
+  ],
+  "properties": {
+    "bin_id": {
+      "type": "string",
+      "description": "Unique bin identifier. Also the Kafka message key, so all events for one bin land on one partition and keep their order.",
+      "minLength": 1
+    },
+    "capacity": {
+      "type": "number",
+      "description": "Maximum capacity of the bin, in litres. Bins are not all the same size, so consumers must divide by this rather than treating current_fill_level as a percentage.",
+      "exclusiveMinimum": 0
+    },
+    "current_fill_level": {
+      "type": "number",
+      "description": "Absolute amount of waste in the bin, in the same unit as capacity. NOT a percentage: fill_pct = current_fill_level / capacity * 100.",
+      "minimum": 0
+    },
+    "battery_level": {
+      "type": "number",
+      "description": "Remaining battery, already a percentage.",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "temperature": {
+      "type": "number",
+      "description": "Bin temperature in degrees Celsius. The range here is what a sensor could physically report; a reading outside it is rejected to the dead-letter topic. Values well above ambient are legitimate and are what fire-risk detection looks for.",
+      "minimum": -40,
+      "maximum": 120
+    },
+    "latitude": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+    "longitude": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    },
+    "zone": {
+      "type": "string",
+      "description": "City zone the bin belongs to. Denormalised onto every event on purpose, so consumers never have to join back to the smart_bins table to group by zone.",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Event time, ISO 8601 with an explicit UTC offset. This is the event-time column every windowed and stateful consumer keys on, and half of the deduplication key (bin_id, timestamp) - so a re-sent duplicate must carry the original timestamp unchanged."
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,15 +58,22 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
-    command: >
-      bash -c "
-      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists
-        --topic smartbin-telemetry-v1 --partitions 12 --replication-factor 1 &&
-      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists
-        --topic smartbin-telemetry-dlq --partitions 3 --replication-factor 1 &&
-      echo 'Topics ready:' &&
-      kafka-topics --bootstrap-server kafka:29092 --list
-      "
+    # Note --if-not-exists leaves an existing topic alone, partition count
+    # included. A topic auto-created earlier with one partition therefore stays
+    # at one: adding partitions later would change which partition a bin's key
+    # hashes to, breaking the per-bin ordering the stateful query depends on.
+    # Delete the topic and let this recreate it. The describe at the end prints
+    # what the topics actually are, so a stale one is visible rather than
+    # assumed.
+    command:
+      - bash
+      - -c
+      - |
+        set -e
+        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic smartbin-telemetry-v1 --partitions 12 --replication-factor 1
+        kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists --topic smartbin-telemetry-dlq --partitions 3 --replication-factor 1
+        kafka-topics --bootstrap-server kafka:29092 --describe --topic smartbin-telemetry-v1 | head -1
+        kafka-topics --bootstrap-server kafka:29092 --describe --topic smartbin-telemetry-dlq | head -1
     restart: "no"
 
   data_simulator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,17 @@ services:
     # producer and the consumer cannot end up pointed at different topics.
     env_file:
       - ./services/data-simulator/.env.docker
+    ports:
+      # The Spark UI. This is the only place the streaming queries report input
+      # rate, batch duration, watermark position and state store size per query
+      # - the Structured Streaming tab is the first thing to open when a query
+      # looks stalled. Unpublished it runs, but nothing outside the container
+      # can reach it.
+      #
+      # 4040 is the streaming application; 4041 is the nightly batch job, which
+      # runs alongside it and needs a port of its own.
+      - "4040:4040"
+      - "4041:4041"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,35 @@ services:
       KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
       CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'
+    healthcheck:
+      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
+
+  # Creates the topics explicitly instead of letting the broker auto-create
+  # them. An auto-created topic gets the broker default of a single partition,
+  # which pins the entire stream to one consumer task no matter how many cores
+  # are available. The producer already keys every message by bin_id, so
+  # splitting across partitions keeps each bin's events in order on one
+  # partition - which the stateful processing downstream depends on.
+  kafka_init:
+    image: confluentinc/cp-kafka:7.4.1
+    container_name: smartbin_kafka_init
+    depends_on:
+      kafka:
+        condition: service_healthy
+    command: >
+      bash -c "
+      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists
+        --topic smartbin-telemetry-v1 --partitions 12 --replication-factor 1 &&
+      kafka-topics --bootstrap-server kafka:29092 --create --if-not-exists
+        --topic smartbin-telemetry-dlq --partitions 3 --replication-factor 1 &&
+      echo 'Topics ready:' &&
+      kafka-topics --bootstrap-server kafka:29092 --list
+      "
+    restart: "no"
 
   data_simulator:
     build:
@@ -50,6 +79,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      kafka_init:
+        condition: service_completed_successfully
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,10 @@ services:
       # runs alongside it and needs a port of its own.
       - "4040:4040"
       - "4041:4041"
+    # Four streaming queries need longer than the ten second default to finish
+    # the micro-batch they are in and commit their offsets. Too short and every
+    # ordinary stop is a SIGKILL reported as exit 137.
+    stop_grace_period: 60s
     depends_on:
       postgres:
         condition: service_healthy
@@ -124,6 +128,46 @@ services:
       # checkpoints hold every SLA clock and last-seen timestamp in the fleet,
       # so removing this volume erases the pipeline's memory, not its scratch
       # space.
+      - spark_state:/data
+
+  # The rollup job on a timer. It is a separate container rather than a thread
+  # inside the streaming application because a batch job that shares a process
+  # with four streaming queries competes with them for the same executors, and
+  # a failure in it would take them down with it.
+  #
+  # The default interval is fifteen minutes rather than a day. The job is a
+  # handful of aggregates over a small history and its writes are upserts, so
+  # running it often costs almost nothing - and a day's wait would mean the
+  # hourly and daily tables sat empty through every demo and every review.
+  #
+  # ponytail: a sleep loop, not a scheduler. It cannot express "03:00 daily",
+  # it drifts by the job's own duration, and it forgets missed runs on restart.
+  # A real deployment points its own scheduler at the same command - the job is
+  # idempotent, so running it more or less often changes nothing but freshness.
+  rollups:
+    build:
+      context: .
+      dockerfile: services/stream-processor/Dockerfile
+      target: runtime
+    container_name: rollups
+    env_file:
+      - ./services/data-simulator/.env.docker
+    # No `|| true`. A rollup that fails should stop the container so the
+    # failure is visible in `docker compose ps` and the restart policy retries
+    # it, rather than being swallowed by the loop and leaving stale tables
+    # behind with nothing to show for it.
+    command: >
+      sh -c 'while true; do
+        python src/batch/rollups.py;
+        sleep "$${ROLLUP_INTERVAL_SECONDS:-900}";
+      done'
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      # The same Parquet history the streaming pipeline writes. Read only as
+      # far as this job is concerned, but the volume is shared, not copied.
       - spark_state:/data
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,5 +82,32 @@ services:
       kafka_init:
         condition: service_completed_successfully
 
+  stream_processor:
+    build:
+      # Built from the repository root so the shared telemetry contract is
+      # inside the build context. Both services build their view of the payload
+      # from that one file.
+      context: .
+      dockerfile: services/stream-processor/Dockerfile
+      target: runtime
+    container_name: stream_processor
+    # Deliberately the same environment file as the simulator: one source for
+    # the database credentials, the broker address and the topic name means the
+    # producer and the consumer cannot end up pointed at different topics.
+    env_file:
+      - ./services/data-simulator/.env.docker
+    depends_on:
+      postgres:
+        condition: service_healthy
+      kafka_init:
+        condition: service_completed_successfully
+    volumes:
+      # Checkpoints and the Parquet history. This is not a cache - the
+      # checkpoints hold every SLA clock and last-seen timestamp in the fleet,
+      # so removing this volume erases the pipeline's memory, not its scratch
+      # space.
+      - spark_state:/data
+
 volumes:
   postgres_data:
+  spark_state:

--- a/services/data-simulator/.env.local.example
+++ b/services/data-simulator/.env.local.example
@@ -20,9 +20,28 @@ FAULT_INJECTION_RATE=0.12
 # Demo profile. The defaults in src/config.py are paced like a real bin, which
 # means an hour and a half before the first bin is critical and about two hours
 # before a battery alert. Uncomment these to compress that into minutes when you
-# need to show the pipeline working. Everything downstream is unaffected: the
-# fire-risk temperature ramp scales with fill level, so it needs no adjusting.
+# need to show the pipeline working. The fire-risk temperature ramp scales with
+# fill level, so it needs no adjusting.
+#
+# This file is read by both services, so the second half is the stream
+# processor's. Speeding up the simulator alone is not enough and is the easy
+# mistake to make: the SLA clocks, the offline timeout and the stuck-sensor
+# count are all the processor's, and left at their real-world values a bin
+# still takes two hours to breach its SLA no matter how fast it fills.
+#
+# The dashboard views are built from these same numbers at startup, so they
+# stay consistent with the alerts - but that means changing them requires a
+# restart of the stream processor, not just of the simulator.
+#
+# The simulator's pacing
 # FILL_RATE_PCT_MIN=0.5
 # FILL_RATE_PCT_MAX=5.0
 # BATTERY_DRAIN_MIN=0.5
 # BATTERY_DRAIN_MAX=2.0
+#
+# The processor's clocks
+# SLA_CRITICAL_MINUTES=3
+# SLA_OVERFLOW_MINUTES=2
+# OFFLINE_AFTER_MINUTES=3
+# STUCK_READING_COUNT=6
+# WATERMARK=2 minutes

--- a/services/data-simulator/.env.local.example
+++ b/services/data-simulator/.env.local.example
@@ -11,3 +11,18 @@ KAFKA_TOPIC=smartbin-telemetry-v1
 
 NUMBER_OF_BINS=100
 SIMULATION_INTERVAL=5
+
+# Fault injection. A share of bins misbehave on purpose so the offline,
+# stuck-sensor, duplicate, impossible-value and fire-risk detectors downstream
+# have something to detect. Set to 0 for a fleet where nothing ever goes wrong.
+FAULT_INJECTION_RATE=0.12
+
+# Demo profile. The defaults in src/config.py are paced like a real bin, which
+# means an hour and a half before the first bin is critical and about two hours
+# before a battery alert. Uncomment these to compress that into minutes when you
+# need to show the pipeline working. Everything downstream is unaffected: the
+# fire-risk temperature ramp scales with fill level, so it needs no adjusting.
+# FILL_RATE_PCT_MIN=0.5
+# FILL_RATE_PCT_MAX=5.0
+# BATTERY_DRAIN_MIN=0.5
+# BATTERY_DRAIN_MAX=2.0

--- a/services/data-simulator/alembic.ini
+++ b/services/data-simulator/alembic.ini
@@ -3,3 +3,49 @@ script_location = alembic
 prepend_sys_path = .
 path_separator = os
 sqlalchemy.url =
+
+# Logging.
+#
+# Without these sections Alembic's loggers are never configured, so
+# `alembic upgrade head` completes in total silence - no "Running upgrade"
+# line, no confirmation of which revision was applied. A migration that
+# silently did nothing looked identical to one that worked, on a command whose
+# whole job is changing the shape of the database.
+#
+# `env.py` calls `fileConfig` to load this.
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+# INFO here emits every executed statement, which buries the migration output.
+# Raise it to INFO temporarily when a migration is doing something unexpected.
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/services/data-simulator/alembic/env.py
+++ b/services/data-simulator/alembic/env.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from logging.config import fileConfig
 from pathlib import Path
 
 from alembic import context
@@ -13,6 +14,17 @@ from config import get_settings  # noqa: E402
 from database import Base  # noqa: E402
 
 config = context.config
+
+# Configure logging from alembic.ini, so an upgrade reports which revisions it
+# applied instead of running in silence.
+#
+# disable_existing_loggers is off deliberately. The default would tear down
+# every logger already configured in the process, which matters because this
+# file is executed inside the test suite by `command.upgrade` - the default
+# would silence pytest's own logging partway through a run.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
+
 if not config.get_main_option("sqlalchemy.url"):
     config.set_main_option("sqlalchemy.url", get_settings().DATABASE_URL.replace("%", "%%"))
 target_metadata = Base.metadata

--- a/services/data-simulator/src/config.py
+++ b/services/data-simulator/src/config.py
@@ -16,6 +16,52 @@ class Settings(BaseSettings):
     NUMBER_OF_BINS: int = 100
     SIMULATION_INTERVAL: int = 5
 
+    # How fast a bin fills per tick, as a percentage of its own capacity.
+    #
+    # A percentage rather than a number of litres, because bins are not all the
+    # same size: a fixed litres-per-tick rate fills a 660 litre bin more than
+    # six times slower in percentage terms, and since every threshold downstream
+    # is a percentage, the largest bins would never cross any of them.
+    #
+    # The defaults are paced for a real bin: at a 5 second interval a bin of any
+    # size takes roughly an hour and a quarter to reach a critical level. This
+    # matters because the SLA rules downstream allow 2 hours to collect a
+    # critical bin - at the old rate a bin overflowed about forty times before
+    # one SLA clock expired. See .env.local.example for a faster demo profile.
+    FILL_RATE_PCT_MIN: float = 0.02
+    FILL_RATE_PCT_MAX: float = 0.15
+
+    # Battery drain per tick, as a percentage. Reaches the 20% maintenance
+    # threshold in about two hours, so a run long enough to show a collection
+    # also shows a battery alert.
+    BATTERY_DRAIN_MIN: float = 0.01
+    BATTERY_DRAIN_MAX: float = 0.1
+
+    # A bin is only collected once it is worth collecting.
+    #
+    # This threshold must sit ABOVE the critical level consumers alert on (80%),
+    # or bins are emptied on the way up and never once register as critical -
+    # no collection list, no SLA clock, and no fire risk, since that rule needs
+    # a bin to be nearly full as well as hot.
+    #
+    # Emptying at an arbitrary level is also not recognised as a collection
+    # downstream, which defines one as a drop from above 60% to below 20%.
+    COLLECTION_THRESHOLD_PCT: float = 85.0
+    COLLECTION_CHANCE_PCT: int = 5
+
+    # Ambient temperature band for a healthy bin, in Celsius.
+    TEMP_NORMAL_MIN: float = 20.0
+    TEMP_NORMAL_MAX: float = 35.0
+
+    # Ceiling for a bin with the HOT fault injected. Fire-risk detection looks
+    # for temperature above 70 C, so this has to sit above that or the rule
+    # could never fire and the detector could never be shown working.
+    TEMP_FIRE_MAX: float = 90.0
+
+    # Share of bins that misbehave on purpose. Without faulty bins, the offline,
+    # stuck-sensor, duplicate and fire-risk detectors have nothing to detect.
+    FAULT_INJECTION_RATE: float = 0.12
+
     @computed_field
     @property
     def DATABASE_URL(self) -> str:

--- a/services/data-simulator/src/config.py
+++ b/services/data-simulator/src/config.py
@@ -62,6 +62,15 @@ class Settings(BaseSettings):
     # stuck-sensor, duplicate and fire-risk detectors have nothing to detect.
     FAULT_INJECTION_RATE: float = 0.12
 
+    # How many readings a bin with the SILENT fault sends before going quiet.
+    #
+    # It has to send some. Dead-device detection works by arming a timer when a
+    # bin reports and firing when the timer expires, so a bin that never reports
+    # at all is not detected as dead - it is simply never known about, and no
+    # alert can be raised for a device nothing has ever heard from. A device
+    # that reports and then dies is also the realistic failure.
+    SILENCE_AFTER_READINGS: int = 10
+
     @computed_field
     @property
     def DATABASE_URL(self) -> str:

--- a/services/data-simulator/src/main.py
+++ b/services/data-simulator/src/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import signal
 from kafka_producer import kafka_client
-from simulator.simulation_manager import SimulationManager
+from simulator.simulation_manager import SchemaNotReadyError, SimulationManager
 from database import engine
 import sys
 
@@ -14,46 +14,19 @@ setup_logging()
 logger = logging.getLogger(__name__)
 
 
-async def main():
-    logger.info("Initializing Data Simulator")
+async def shutdown(manager):
+    """
+    Release everything the process holds, in order, tolerating failures.
 
-    # Start Kafka Producer
-    logger.info("Initializing Kafka Client")
-
-    await kafka_client.start()
-
-    logger.info("Kafka Client Started Successfully")
-
-    # Start Manager
-    logger.info("Initializing Simulation Manager")
-    manager = SimulationManager()
-    await manager.initialize()
-
-    logger.info("Simulation Manager Started Successfully")
-
-    # Handle graceful shutdown
-    loop = asyncio.get_running_loop()
-    stop_event = asyncio.Event()
-
-    def handle_shutdown(*args):
-        logger.info("Shutdown signal received")
-        loop.call_soon_threadsafe(stop_event.set)
-
-    if sys.platform == "win32":
-        # Windows does not support loop.add_signal_handler
-        signal.signal(signal.SIGINT, handle_shutdown)
-        signal.signal(signal.SIGTERM, handle_shutdown)
-    else:
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, lambda: handle_shutdown())
-
-    await stop_event.wait()
-
-    # Cleanup with timeout
-    try:
-        await asyncio.wait_for(manager.stop(), timeout=5.0)
-    except Exception as e:
-        logger.warning(f"Manager stop timed out or failed: {e}")
+    Each step is guarded so one failure cannot skip the ones after it - a
+    producer left open because the manager stopped badly is a resource leak the
+    logs would then blame on the wrong thing.
+    """
+    if manager is not None:
+        try:
+            await asyncio.wait_for(manager.stop(), timeout=5.0)
+        except Exception as e:
+            logger.warning(f"Manager stop timed out or failed: {e}")
 
     try:
         await asyncio.wait_for(kafka_client.stop(), timeout=5.0)
@@ -65,8 +38,62 @@ async def main():
     except Exception as e:
         logger.warning(f"Engine disposal failed: {e}")
 
-    logger.info("Shutdown complete")
+
+async def main():
+    logger.info("Initializing Data Simulator")
+
+    manager = None
+
+    # Start Kafka Producer
+    logger.info("Initializing Kafka Client")
+
+    await kafka_client.start()
+
+    logger.info("Kafka Client Started Successfully")
+
+    # Everything past this point runs with the producer open, so cleanup has to
+    # happen on the way out whether startup succeeded or not. It previously sat
+    # after the shutdown wait, so a failure to start left the Kafka producer
+    # open and the process died complaining about it instead of about the
+    # actual problem.
+    try:
+        # Start Manager
+        logger.info("Initializing Simulation Manager")
+        manager = SimulationManager()
+        await manager.initialize()
+
+        logger.info("Simulation Manager Started Successfully")
+
+        # Handle graceful shutdown
+        loop = asyncio.get_running_loop()
+        stop_event = asyncio.Event()
+
+        def handle_shutdown(*args):
+            logger.info("Shutdown signal received")
+            loop.call_soon_threadsafe(stop_event.set)
+
+        if sys.platform == "win32":
+            # Windows does not support loop.add_signal_handler
+            signal.signal(signal.SIGINT, handle_shutdown)
+            signal.signal(signal.SIGTERM, handle_shutdown)
+        else:
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                loop.add_signal_handler(sig, lambda: handle_shutdown())
+
+        await stop_event.wait()
+
+    except SchemaNotReadyError as error:
+        # An operator forgot a documented step. Report what to do and stop -
+        # a traceback here only buries the instruction.
+        logger.error("%s", error)
+        return 1
+
+    finally:
+        await shutdown(manager)
+        logger.info("Shutdown complete")
+
+    return 0
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    sys.exit(asyncio.run(main()))

--- a/services/data-simulator/src/models/bin.py
+++ b/services/data-simulator/src/models/bin.py
@@ -42,6 +42,12 @@ class Bin:
         temperature (float):
             Simulated temperature in degrees Celsius.
 
+        fault_mode (str | None):
+            The fault this bin has been told to exhibit, or None for a healthy
+            bin. The bin only records the label; acting on it belongs to
+            `BinSimulator`, in keeping with this class holding no simulation
+            logic. See `simulator.bin_simulator.FAULT_MODES`.
+
     Methods:
         update_location(latitude, longitude):
             Updates the geographical coordinates of the bin.
@@ -58,16 +64,28 @@ class Bin:
         latitude: float,
         longitude: float,
         zone: str,
+        fault_mode: str | None = None,
     ):
         self.bin_id = bin_id
         self.capacity = capacity
         self.latitude = latitude
         self.longitude = longitude
         self.zone = zone
+        self.fault_mode = fault_mode
 
         self.current_fill_level = 0.0
         self.battery_level = 100.0
         self.temperature = 25.0
+
+    @property
+    def fill_pct(self) -> float:
+        """
+        Fill level as a percentage of this bin's capacity.
+
+        Bins are not all the same size, so the raw fill level cannot be compared
+        against a percentage threshold directly.
+        """
+        return self.current_fill_level / self.capacity * 100
 
     def update_location(self, latitude: float, longitude: float):
         """

--- a/services/data-simulator/src/seed.py
+++ b/services/data-simulator/src/seed.py
@@ -12,6 +12,13 @@ from config import get_settings
 settings = get_settings()
 fake = Faker()
 
+MAX_BINS_PER_RUN = 5000
+
+# Real bins are not all one size. Seeding a single capacity makes the absolute
+# fill level and the fill percentage numerically identical, which hides every
+# place downstream that compares a raw level against a percentage threshold.
+BIN_CAPACITIES = (100.0, 240.0, 660.0)
+
 HYDERABAD_CENTER = (17.3850, 78.4867)
 ZONE_OFFSETS = {
     "CENTRAL": ((-0.02, 0.02), (-0.02, 0.02)),
@@ -23,8 +30,11 @@ ZONE_OFFSETS = {
 
 
 async def seed_db(count: int, clear: bool):
-    if count > 500:
-        print("Error: For safety, you cannot seed more than 500 bins at a time.")
+    if count > MAX_BINS_PER_RUN:
+        print(
+            f"Error: For safety, you cannot seed more than "
+            f"{MAX_BINS_PER_RUN} bins at a time."
+        )
         return
 
     print("Connecting to database...")
@@ -46,7 +56,7 @@ async def seed_db(count: int, clear: bool):
                 latitude_offset, longitude_offset = ZONE_OFFSETS[zone]
                 new_bin = SmartBin(
                     bin_id=bin_id,
-                    capacity=100.0,
+                    capacity=fake.random_element(BIN_CAPACITIES),
                     latitude=HYDERABAD_CENTER[0]
                     + uniform(*latitude_offset),
                     longitude=HYDERABAD_CENTER[1]

--- a/services/data-simulator/src/simulator/bin_simulator.py
+++ b/services/data-simulator/src/simulator/bin_simulator.py
@@ -179,7 +179,11 @@ class BinSimulator:
             try:
                 await self._task
             except asyncio.CancelledError:
-                logger.warning(
+                # Debug, not warning: cancelling the task is how stop() works,
+                # so this is the expected path. At warning level an ordinary
+                # shutdown buried the log under one line per bin - which trains
+                # everyone to ignore warnings from this service.
+                logger.debug(
                     "Simulation task cancelled for bin '%s'.",
                     self.bin.bin_id,
                 )

--- a/services/data-simulator/src/simulator/bin_simulator.py
+++ b/services/data-simulator/src/simulator/bin_simulator.py
@@ -12,6 +12,69 @@ settings = get_settings()
 
 fake = Faker()
 
+# The ways a bin is allowed to misbehave.
+#
+# Every one of these exists to give a downstream detector something to detect.
+# A simulation in which nothing ever goes wrong can only demonstrate the happy
+# path, so the offline, stuck-sensor, duplicate, impossible-value, fire-risk and
+# abnormal-jump rules would all be written and never once observed firing.
+#
+#   SILENT       stops publishing         -> dead device detection
+#   FROZEN       republishes one reading  -> stuck sensor detection
+#   SPIKE        publishes a value no sensor could produce -> validation, dead letters
+#   DUPLICATE    re-sends the last event verbatim -> deduplication
+#   HOT          runs far above ambient   -> fire risk detection
+#   JUMP         one large but legal fill jump -> abnormal jump detection
+#   UNCOLLECTED  is never emptied         -> SLA breach detection
+FAULT_MODES = (
+    "SILENT",
+    "FROZEN",
+    "SPIKE",
+    "DUPLICATE",
+    "HOT",
+    "JUMP",
+    "UNCOLLECTED",
+)
+
+# A temperature no real sensor reports, used by the SPIKE fault. This sits
+# outside the range the telemetry contract declares valid, so consumers reject
+# it, which is the point - unlike a HOT bin, which is extreme but believable.
+IMPOSSIBLE_TEMPERATURE = 150.0
+
+
+def assign_fault_modes(bins: list[Bin], rate: float | None = None) -> None:
+    """
+    Mark a share of bins as faulty, cycling through the fault modes.
+
+    Assignment is deliberately deterministic rather than a random draw per bin.
+    Drawing independently means a small fleet can easily end up with no HOT bin
+    and therefore no fire-risk alert anywhere in the run, which looks identical
+    to a broken detector. Cycling guarantees that once at least
+    ``len(FAULT_MODES)`` bins are marked, every mode is represented exactly.
+
+    Args:
+        bins:
+            The bins to mark, modified in place.
+
+        rate:
+            Fraction of bins to make faulty. Defaults to the configured
+            ``FAULT_INJECTION_RATE``. Zero disables fault injection entirely.
+    """
+    if rate is None:
+        rate = settings.FAULT_INJECTION_RATE
+
+    faulty_count = int(len(bins) * rate)
+
+    for index in range(faulty_count):
+        bins[index].fault_mode = FAULT_MODES[index % len(FAULT_MODES)]
+
+    if faulty_count:
+        logger.info(
+            "Injected faults into %d of %d bin(s).",
+            faulty_count,
+            len(bins),
+        )
+
 
 class BinSimulator:
     """
@@ -57,6 +120,12 @@ class BinSimulator:
         self.bin = bin
         self._running = False
         self._task: asyncio.Task | None = None
+
+        # Retained so the DUPLICATE fault can re-send a previous event exactly
+        # as it went out the first time. Deduplication downstream keys on
+        # (bin_id, timestamp), so a "duplicate" carrying a fresh timestamp is
+        # not a duplicate at all and would silently pass straight through.
+        self._last_payload: dict | None = None
 
     def start(self) -> None:
         """
@@ -131,12 +200,16 @@ class BinSimulator:
 
         while self._running:
             self._simulate()
-            logger.debug("Sending telemetry for %s", self.bin.bin_id)
-            await kafka_client.send_telemetry(
-                self.bin.bin_id,
-                self.bin.to_payload(),
-            )
-            logger.debug("Telemetry sent for %s", self.bin.bin_id)
+
+            payload = self._next_payload()
+
+            if payload is not None:
+                logger.debug("Sending telemetry for %s", self.bin.bin_id)
+                await kafka_client.send_telemetry(
+                    self.bin.bin_id,
+                    payload,
+                )
+                logger.debug("Telemetry sent for %s", self.bin.bin_id)
 
             await asyncio.sleep(
                 settings.SIMULATION_INTERVAL,
@@ -147,56 +220,173 @@ class BinSimulator:
             self.bin.bin_id,
         )
 
+    def _next_payload(self) -> dict | None:
+        """
+        Build the payload to publish this tick, or None to publish nothing.
+
+        This is where the two faults that are about *publishing* rather than
+        about bin state are applied. Everything else is handled in
+        :meth:`_simulate`.
+
+        Returns:
+            The telemetry payload, or None if this bin is currently silent.
+        """
+        if self.bin.fault_mode == "SILENT":
+            logger.debug(
+                "Bin '%s' is silent; publishing nothing.",
+                self.bin.bin_id,
+            )
+            return None
+
+        # Re-send the previous event byte for byte, original timestamp included.
+        # Alternating means a duplicate is always followed by a fresh reading,
+        # so the bin still makes progress instead of stalling on one event.
+        if self.bin.fault_mode == "DUPLICATE" and self._last_payload is not None:
+            duplicate = self._last_payload
+            self._last_payload = None
+
+            logger.debug(
+                "Bin '%s' is re-sending its previous event.",
+                self.bin.bin_id,
+            )
+            return duplicate
+
+        self._last_payload = self.bin.to_payload()
+        return self._last_payload
+
     def _simulate(self) -> None:
         """
         Updates the simulated state of the bin.
 
         The simulation models:
-            - Fill level changes
+            - Fill level changes, including collection
             - Battery consumption
             - Temperature drift
+
+        A bin with the FROZEN fault is skipped entirely, so it keeps reporting
+        the reading it was last on. The remaining state-level faults are applied
+        by the individual steps below.
         """
-        if fake.boolean(chance_of_getting_true=5):
+        if self.bin.fault_mode == "FROZEN":
+            logger.debug(
+                "Bin '%s' is frozen on its last reading.",
+                self.bin.bin_id,
+            )
+            return
+
+        self._simulate_fill()
+        self._simulate_battery()
+        self._simulate_temperature()
+
+        logger.debug(
+            "Simulated bin '%s' | Fill: %.2f%% | Battery: %.2f%% | Temperature: %.2f C",
+            self.bin.bin_id,
+            self.bin.fill_pct,
+            self.bin.battery_level,
+            self.bin.temperature,
+        )
+
+    def _simulate_fill(self) -> None:
+        """
+        Advances the fill level, emptying the bin if it is collected.
+
+        A bin is only ever collected once it is actually worth collecting.
+        Emptying at any fill level, as this previously did, has two problems: a
+        bin is emptied so often that it never reaches a critical level at a
+        realistic fill rate, and a drop from a low level is not something
+        downstream collection detection recognises, so it registers as neither a
+        collection nor anything else.
+        """
+        # An UNCOLLECTED bin is one the truck never comes for. It is the only
+        # way an SLA clock is ever allowed to run out: every other bin is
+        # emptied long inside the two hours the rules allow, so without this
+        # fault the SLA breach rule could never be observed firing.
+        collectable = (
+            self.bin.fill_pct >= settings.COLLECTION_THRESHOLD_PCT
+            and self.bin.fault_mode != "UNCOLLECTED"
+        )
+
+        if collectable and fake.boolean(
+            chance_of_getting_true=settings.COLLECTION_CHANCE_PCT
+        ):
             self.bin.current_fill_level = 0
 
             logger.debug(
                 "Bin '%s' was emptied.",
                 self.bin.bin_id,
             )
+            return
 
-        else:
-            increase = fake.pyfloat(
-                min_value=0.5,
-                max_value=5.0,
+        # Scaled by capacity so bins of every size cross the percentage
+        # thresholds downstream at the same pace.
+        increase = (
+            self.bin.capacity
+            * fake.pyfloat(
+                min_value=settings.FILL_RATE_PCT_MIN,
+                max_value=settings.FILL_RATE_PCT_MAX,
             )
+            / 100
+        )
 
-            self.bin.current_fill_level = min(
-                self.bin.capacity,
-                self.bin.current_fill_level + increase,
-            )
+        # A jump large enough to look wrong, but still a level the bin could
+        # legitimately hold - so it passes validation and has to be caught by
+        # comparing against the previous reading rather than by a range check.
+        if self.bin.fault_mode == "JUMP":
+            increase = self.bin.capacity * 0.4
 
+        self.bin.current_fill_level = min(
+            self.bin.capacity,
+            self.bin.current_fill_level + increase,
+        )
+
+    def _simulate_battery(self) -> None:
+        """
+        Drains the battery, which never goes below zero.
+        """
         self.bin.battery_level = max(
             0,
             self.bin.battery_level
             - fake.pyfloat(
-                min_value=0.01,
-                max_value=0.1,
+                min_value=settings.BATTERY_DRAIN_MIN,
+                max_value=settings.BATTERY_DRAIN_MAX,
             ),
         )
 
+    def _simulate_temperature(self) -> None:
+        """
+        Updates the temperature.
+
+        A healthy bin drifts within the ambient band. The two faults leave it
+        deliberately:
+
+        SPIKE reports a value no sensor could produce, which consumers reject
+        outright.
+
+        HOT reports a real but dangerous temperature, scaled by how full the bin
+        is. Fire risk means hot *and* nearly full together, so a bin that simply
+        pinned itself to a high temperature from empty would satisfy one half of
+        that rule forever and the other half never, and the alert would still
+        not fire. Scaling with fill level means the bin crosses the 70 C fire
+        threshold at around 64% full and is well past it by the time it is full
+        enough to matter - and it does so at any capacity and any fill rate,
+        with nothing to re-tune when those change.
+        """
+        if self.bin.fault_mode == "SPIKE":
+            self.bin.temperature = IMPOSSIBLE_TEMPERATURE
+            return
+
+        if self.bin.fault_mode == "HOT":
+            headroom = settings.TEMP_FIRE_MAX - settings.TEMP_NORMAL_MAX
+            self.bin.temperature = (
+                settings.TEMP_NORMAL_MAX + headroom * self.bin.fill_pct / 100
+            )
+            return
+
         self.bin.temperature = min(
-            35.0,
+            settings.TEMP_NORMAL_MAX,
             max(
-                20.0,
+                settings.TEMP_NORMAL_MIN,
                 self.bin.temperature
                 + uniform(-0.5, 0.5),
             ),
-        )
-
-        logger.debug(
-            "Simulated bin '%s' | Fill: %.2f%% | Battery: %.2f%% | Temperature: %.2f C",
-            self.bin.bin_id,
-            self.bin.current_fill_level,
-            self.bin.battery_level,
-            self.bin.temperature,
         )

--- a/services/data-simulator/src/simulator/bin_simulator.py
+++ b/services/data-simulator/src/simulator/bin_simulator.py
@@ -21,7 +21,7 @@ fake = Faker()
 #
 #   SILENT       stops publishing         -> dead device detection
 #   FROZEN       republishes one reading  -> stuck sensor detection
-#   SPIKE        publishes a value no sensor could produce -> validation, dead letters
+#   SPIKE        reports values no sensor could produce -> sensor fault, dead letters
 #   DUPLICATE    re-sends the last event verbatim -> deduplication
 #   HOT          runs far above ambient   -> fire risk detection
 #   JUMP         one large but legal fill jump -> abnormal jump detection
@@ -262,9 +262,37 @@ class BinSimulator:
             self._published += 1
             return duplicate
 
-        self._last_payload = self.bin.to_payload()
+        payload = self.bin.to_payload()
+
+        if self.bin.fault_mode == "SPIKE":
+            payload = self._corrupt(payload)
+
+        self._last_payload = payload
         self._published += 1
         return self._last_payload
+
+    def _corrupt(self, payload: dict) -> dict:
+        """
+        Report a value no sensor could produce, leaving the bin itself alone.
+
+        A broken sensor is a fault in what is *reported*, not in what is true,
+        so this corrupts the outgoing payload rather than the bin's state. The
+        bin carries on filling normally underneath, which is what makes it
+        worth still tracking.
+
+        Alternates between two kinds of nonsense, because consumers treat them
+        differently and both paths need exercising: an impossible temperature
+        says nothing about how full the bin is and can be discarded on its own,
+        while an impossible fill level leaves nothing usable in the message.
+        """
+        corrupted = dict(payload)
+
+        if self._published % 2 == 0:
+            corrupted["temperature"] = IMPOSSIBLE_TEMPERATURE
+        else:
+            corrupted["current_fill_level"] = round(self.bin.capacity * 1.5, 2)
+
+        return corrupted
 
     def _simulate(self) -> None:
         """
@@ -383,10 +411,6 @@ class BinSimulator:
         enough to matter - and it does so at any capacity and any fill rate,
         with nothing to re-tune when those change.
         """
-        if self.bin.fault_mode == "SPIKE":
-            self.bin.temperature = IMPOSSIBLE_TEMPERATURE
-            return
-
         if self.bin.fault_mode == "HOT":
             headroom = settings.TEMP_FIRE_MAX - settings.TEMP_NORMAL_MAX
             self.bin.temperature = (

--- a/services/data-simulator/src/simulator/bin_simulator.py
+++ b/services/data-simulator/src/simulator/bin_simulator.py
@@ -127,6 +127,10 @@ class BinSimulator:
         # not a duplicate at all and would silently pass straight through.
         self._last_payload: dict | None = None
 
+        # How many readings this bin has published, used by the SILENT fault to
+        # report for a while before dying.
+        self._published = 0
+
     def start(self) -> None:
         """
         Starts the telemetry simulation task.
@@ -231,12 +235,18 @@ class BinSimulator:
         Returns:
             The telemetry payload, or None if this bin is currently silent.
         """
+        # A silent bin reports for a while and then dies, rather than never
+        # reporting at all. Dead-device detection arms a timer when a bin
+        # reports and raises the alert when that timer expires, so a bin that
+        # has never once been heard from cannot be reported as lost - nothing
+        # downstream knows it exists.
         if self.bin.fault_mode == "SILENT":
-            logger.debug(
-                "Bin '%s' is silent; publishing nothing.",
-                self.bin.bin_id,
-            )
-            return None
+            if self._published >= settings.SILENCE_AFTER_READINGS:
+                logger.debug(
+                    "Bin '%s' has gone silent; publishing nothing.",
+                    self.bin.bin_id,
+                )
+                return None
 
         # Re-send the previous event byte for byte, original timestamp included.
         # Alternating means a duplicate is always followed by a fresh reading,
@@ -249,9 +259,11 @@ class BinSimulator:
                 "Bin '%s' is re-sending its previous event.",
                 self.bin.bin_id,
             )
+            self._published += 1
             return duplicate
 
         self._last_payload = self.bin.to_payload()
+        self._published += 1
         return self._last_payload
 
     def _simulate(self) -> None:

--- a/services/data-simulator/src/simulator/simulation_manager.py
+++ b/services/data-simulator/src/simulator/simulation_manager.py
@@ -1,12 +1,23 @@
 from models.bin import Bin
 from simulator.bin_simulator import BinSimulator, assign_fault_modes
 
-from database import AsyncSessionLocal, SmartBin
-from sqlalchemy import select
+from database import AsyncSessionLocal, SmartBin, engine
+from sqlalchemy import inspect, select
 
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+class SchemaNotReadyError(RuntimeError):
+    """The database has not been migrated yet.
+
+    Raised instead of letting the driver's own error escape. A missing table
+    surfaces from asyncpg as a thirty-line traceback with the one useful line
+    at the bottom, which tells an operator nothing about what to do next -
+    and migrations are deliberately a manual step here, so this is an ordinary
+    thing to get wrong rather than an exceptional one.
+    """
 
 
 class SimulationManager:
@@ -31,10 +42,44 @@ class SimulationManager:
 
         self._simulators: dict[str, BinSimulator] = {}
 
+    async def require_schema(self) -> None:
+        """
+        Check the bins table exists before anything tries to read it.
+
+        Migrations are a deliberate manual step, so starting against an
+        unmigrated database is a routine mistake rather than an exceptional
+        one, and deserves an answer rather than a stack trace.
+
+        Raises:
+            SchemaNotReadyError:
+                The table is missing, with the command that creates it.
+        """
+        async with engine.connect() as connection:
+            has_table = await connection.run_sync(
+                lambda sync_connection: inspect(sync_connection).has_table(
+                    SmartBin.__tablename__
+                )
+            )
+
+        if not has_table:
+            raise SchemaNotReadyError(
+                f"The '{SmartBin.__tablename__}' table does not exist. "
+                "Migrations are a manual step; run them before starting the "
+                "simulator:\n"
+                "    docker compose run --rm data_simulator alembic upgrade head\n"
+                "    docker compose run --rm data_simulator python src/seed.py --count 200"
+            )
+
     async def initialize(self) -> None:
         """
         Loads all bins from the database and starts their simulators.
+
+        Raises:
+            SchemaNotReadyError:
+                The database has not been migrated.
         """
+        await self.require_schema()
+
         logger.info("Loading bins from database...")
 
         async with AsyncSessionLocal() as session:
@@ -66,6 +111,17 @@ class SimulationManager:
                 simulator.start()
 
                 self._simulators[bin.bin_id] = simulator
+
+        if not self._simulators:
+            # Not fatal - bins can be added later - but silence here reads as a
+            # broken simulator when it is really an unseeded database.
+            logger.warning(
+                "No ACTIVE bins found, so nothing will be published. Seed the "
+                "database:\n"
+                "    docker compose run --rm data_simulator python src/seed.py "
+                "--count 200"
+            )
+            return
 
         logger.info(
             "Started %d simulator(s).",

--- a/services/data-simulator/src/simulator/simulation_manager.py
+++ b/services/data-simulator/src/simulator/simulation_manager.py
@@ -1,5 +1,5 @@
 from models.bin import Bin
-from simulator.bin_simulator import BinSimulator
+from simulator.bin_simulator import BinSimulator, assign_fault_modes
 
 from database import AsyncSessionLocal, SmartBin
 from sqlalchemy import select
@@ -45,16 +45,23 @@ class SimulationManager:
             )
             db_bins = result.scalars().all()
 
-            for db_bin in db_bins:
-
-                bin = Bin(
+            bins = [
+                Bin(
                     bin_id=db_bin.bin_id,
                     latitude=db_bin.latitude,
                     longitude=db_bin.longitude,
                     capacity=db_bin.capacity,
                     zone=db_bin.zone,
                 )
+                for db_bin in db_bins
+            ]
 
+            # Faults are assigned across the whole fleet at once rather than per
+            # bin, so the share of faulty bins and the spread of fault modes are
+            # both known rather than left to chance.
+            assign_fault_modes(bins)
+
+            for bin in bins:
                 simulator = BinSimulator(bin)
                 simulator.start()
 

--- a/services/data-simulator/tests/simulator/test_bin_simulator.py
+++ b/services/data-simulator/tests/simulator/test_bin_simulator.py
@@ -1,7 +1,10 @@
 import pytest
 from unittest.mock import patch, AsyncMock
+from src.config import get_settings
 from src.models.bin import Bin
 from src.simulator.bin_simulator import BinSimulator
+
+settings = get_settings()
 
 @pytest.fixture
 def bin_instance():
@@ -88,15 +91,46 @@ def test_simulate_empty_bin(mock_fake, bin_instance):
     ensuring the fill level resets to exactly 0.0.
     """
     simulator = BinSimulator(bin_instance)
-    bin_instance.current_fill_level = 50.0
-    
+    # Above the collection threshold, so the bin is worth collecting
+    bin_instance.current_fill_level = settings.COLLECTION_THRESHOLD_PCT + 5.0
+
     # Emptying the bin
     mock_fake.boolean.return_value = True
     mock_fake.pyfloat.return_value = 0.1
-    
+
     simulator._simulate()
-    
+
     assert bin_instance.current_fill_level == 0.0
+
+
+def test_bins_go_critical_before_they_are_collected():
+    """Collection happens above the level consumers call critical, not below.
+
+    If bins were emptied on the way up to 80% they would never once register as
+    critical: no collection list, no SLA clock, and no fire risk, since that
+    rule needs a bin to be nearly full as well as hot.
+    """
+    assert settings.COLLECTION_THRESHOLD_PCT > 80.0
+
+
+@patch('src.simulator.bin_simulator.fake')
+def test_simulate_does_not_empty_a_bin_below_the_threshold(mock_fake, bin_instance):
+    """
+    Test that a bin is never collected while it is nearly empty.
+    Collecting at any fill level stops bins ever reaching a critical level at a
+    realistic fill rate, and produces drops that downstream collection detection
+    does not recognise as collections.
+    """
+    simulator = BinSimulator(bin_instance)
+    bin_instance.current_fill_level = 10.0
+
+    # Would empty the bin, if it were full enough to be worth collecting
+    mock_fake.boolean.return_value = True
+    mock_fake.pyfloat.side_effect = [0.1, 0.05]
+
+    simulator._simulate()
+
+    assert bin_instance.current_fill_level == pytest.approx(10.1)
 
 @pytest.mark.asyncio
 @patch('src.simulator.bin_simulator.kafka_client')

--- a/services/data-simulator/tests/simulator/test_faults.py
+++ b/services/data-simulator/tests/simulator/test_faults.py
@@ -174,12 +174,44 @@ async def test_frozen_bin_still_publishes(mock_sleep, mock_kafka_client):
 
 def test_spike_bin_reports_an_impossible_temperature():
     """A spiking bin reports a value no sensor could produce."""
+    simulator = BinSimulator(make_bin("SPIKE"))
+
+    payload = simulator._next_payload()
+
+    assert payload["temperature"] == IMPOSSIBLE_TEMPERATURE
+
+
+def test_spike_bin_also_reports_an_impossible_fill_level():
+    """It alternates, because consumers treat the two kinds differently.
+
+    A bad temperature can be discarded on its own; a bad fill level leaves
+    nothing usable in the message. Both paths need exercising.
+    """
+    simulator = BinSimulator(make_bin("SPIKE"))
+
+    payloads = [simulator._next_payload() for _ in range(4)]
+    overfull = [
+        payload
+        for payload in payloads
+        if payload["current_fill_level"] > payload["capacity"]
+    ]
+
+    assert overfull, "no message ever carried an impossible fill level"
+
+
+def test_a_spiking_bin_keeps_filling_underneath():
+    """The fault is in what is reported, not in what is true.
+
+    A broken sensor does not stop the bin filling, and the bin is still worth
+    tracking - which is only possible if its real state stays sane.
+    """
     bin_instance = make_bin("SPIKE")
     simulator = BinSimulator(bin_instance)
 
-    tick(simulator)
+    tick(simulator, count=10)
 
-    assert bin_instance.temperature == IMPOSSIBLE_TEMPERATURE
+    assert 0 < bin_instance.current_fill_level <= bin_instance.capacity
+    assert bin_instance.temperature <= settings.TEMP_NORMAL_MAX
 
 
 # --------------------------------------------------------------------------

--- a/services/data-simulator/tests/simulator/test_faults.py
+++ b/services/data-simulator/tests/simulator/test_faults.py
@@ -1,0 +1,324 @@
+"""Tests for injected bin faults.
+
+Each fault exists so that one downstream detector has something to detect. These
+tests assert the fault actually produces the condition its detector looks for -
+not merely that a flag was set - because a fault that never produces its
+condition and a detector that never fires are indistinguishable in a demo.
+"""
+
+import pytest
+from unittest.mock import patch, AsyncMock
+
+from src.config import get_settings
+from src.models.bin import Bin
+from src.simulator.bin_simulator import (
+    FAULT_MODES,
+    IMPOSSIBLE_TEMPERATURE,
+    BinSimulator,
+    assign_fault_modes,
+)
+
+settings = get_settings()
+
+# The thresholds the consumer applies. Duplicated here on purpose: if either
+# side moves, these tests should fail rather than quietly agree with themselves.
+FIRE_RISK_TEMPERATURE = 70.0
+FIRE_RISK_FILL_PCT = 80.0
+
+
+def make_bin(fault_mode=None, capacity=100.0):
+    return Bin("bin_1", capacity, 17.4, 78.5, "NORTH", fault_mode=fault_mode)
+
+
+def tick(simulator, count=1):
+    """Advance the simulation by whole ticks."""
+    for _ in range(count):
+        simulator._simulate()
+
+
+# --------------------------------------------------------------------------
+# Fault assignment
+# --------------------------------------------------------------------------
+
+
+def test_assign_fault_modes_covers_every_mode():
+    """Enough faulty bins means every fault mode is represented.
+
+    Drawing per bin independently can leave a small fleet with no HOT bin at
+    all, so no fire-risk alert ever fires and the detector looks broken.
+    """
+    bins = [make_bin() for _ in range(len(FAULT_MODES) * 10)]
+
+    assign_fault_modes(bins, rate=1.0)
+
+    assert {bin_instance.fault_mode for bin_instance in bins} == set(FAULT_MODES)
+
+
+def test_assign_fault_modes_leaves_most_bins_healthy():
+    """Only the configured share of the fleet misbehaves."""
+    bins = [make_bin() for _ in range(100)]
+
+    assign_fault_modes(bins, rate=0.12)
+
+    faulty = [b for b in bins if b.fault_mode is not None]
+    assert len(faulty) == 12
+    assert all(b.fault_mode is None for b in bins[12:])
+
+
+def test_assign_fault_modes_can_be_disabled():
+    """A rate of zero leaves every bin healthy."""
+    bins = [make_bin() for _ in range(50)]
+
+    assign_fault_modes(bins, rate=0.0)
+
+    assert all(b.fault_mode is None for b in bins)
+
+
+# --------------------------------------------------------------------------
+# SILENT - dead device detection
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch("src.simulator.bin_simulator.kafka_client")
+@patch("src.simulator.bin_simulator.asyncio.sleep")
+async def test_silent_bin_publishes_nothing(mock_sleep, mock_kafka_client):
+    """A silent bin stops sending, which is what dead-device detection sees."""
+    mock_kafka_client.send_telemetry = AsyncMock()
+    simulator = BinSimulator(make_bin("SILENT"))
+    simulator._running = True
+
+    async def stop(*args, **kwargs):
+        simulator._running = False
+
+    mock_sleep.side_effect = stop
+
+    await simulator._run()
+
+    mock_kafka_client.send_telemetry.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# FROZEN - stuck sensor detection
+# --------------------------------------------------------------------------
+
+
+def test_frozen_bin_never_changes_its_reading():
+    """A frozen bin repeats one reading, which is a stuck sensor."""
+    bin_instance = make_bin("FROZEN")
+    bin_instance.current_fill_level = 42.0
+    simulator = BinSimulator(bin_instance)
+
+    tick(simulator, count=20)
+
+    assert bin_instance.current_fill_level == 42.0
+
+
+@pytest.mark.asyncio
+@patch("src.simulator.bin_simulator.kafka_client")
+@patch("src.simulator.bin_simulator.asyncio.sleep")
+async def test_frozen_bin_still_publishes(mock_sleep, mock_kafka_client):
+    """A frozen bin keeps reporting - it is stuck, not offline.
+
+    This is what separates it from a SILENT bin: the events keep arriving, so
+    the fault has to be found by noticing the value never moves.
+    """
+    mock_kafka_client.send_telemetry = AsyncMock()
+    simulator = BinSimulator(make_bin("FROZEN"))
+    simulator._running = True
+
+    async def stop(*args, **kwargs):
+        simulator._running = False
+
+    mock_sleep.side_effect = stop
+
+    await simulator._run()
+
+    mock_kafka_client.send_telemetry.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# SPIKE - impossible values, rejected to the dead-letter topic
+# --------------------------------------------------------------------------
+
+
+def test_spike_bin_reports_an_impossible_temperature():
+    """A spiking bin reports a value no sensor could produce."""
+    bin_instance = make_bin("SPIKE")
+    simulator = BinSimulator(bin_instance)
+
+    tick(simulator)
+
+    assert bin_instance.temperature == IMPOSSIBLE_TEMPERATURE
+
+
+# --------------------------------------------------------------------------
+# DUPLICATE - deduplication
+# --------------------------------------------------------------------------
+
+
+def test_duplicate_bin_resends_the_previous_event_unchanged():
+    """A duplicate carries the original timestamp, so it is really a duplicate.
+
+    Deduplication keys on (bin_id, timestamp). Regenerating the timestamp would
+    produce a distinct event that passes straight through, leaving the rule with
+    nothing to remove.
+    """
+    simulator = BinSimulator(make_bin("DUPLICATE"))
+
+    first = simulator._next_payload()
+    second = simulator._next_payload()
+
+    assert second == first
+    assert second["timestamp"] == first["timestamp"]
+
+
+def test_duplicate_bin_alternates_so_it_still_makes_progress():
+    """After re-sending, the bin emits a fresh reading rather than stalling."""
+    simulator = BinSimulator(make_bin("DUPLICATE"))
+
+    first = simulator._next_payload()
+    simulator._next_payload()  # the duplicate
+    third = simulator._next_payload()
+
+    assert third["timestamp"] != first["timestamp"]
+
+
+def test_healthy_bin_never_repeats_an_event():
+    """Deduplication must not have anything to do on a healthy bin."""
+    simulator = BinSimulator(make_bin())
+
+    timestamps = {simulator._next_payload()["timestamp"] for _ in range(5)}
+
+    assert len(timestamps) == 5
+
+
+# --------------------------------------------------------------------------
+# HOT - fire risk detection
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("capacity", [100.0, 240.0, 660.0])
+def test_hot_bin_is_hot_and_full_at_the_same_time(capacity):
+    """A hot bin satisfies both halves of the fire-risk rule together.
+
+    Fire risk means temperature above 70 C *and* fill above 80%. A bin that
+    pinned itself to a high temperature while empty would satisfy one half
+    forever and the other never, and the alert would still not fire. Scaling the
+    temperature with fill level holds at every bin size.
+    """
+    bin_instance = make_bin("HOT", capacity=capacity)
+    simulator = BinSimulator(bin_instance)
+
+    bin_instance.current_fill_level = capacity * 0.85
+    simulator._simulate_temperature()
+
+    assert bin_instance.fill_pct > FIRE_RISK_FILL_PCT
+    assert bin_instance.temperature > FIRE_RISK_TEMPERATURE
+
+
+def test_hot_bin_is_not_yet_alarming_while_half_empty():
+    """A hot bin below the fill threshold does not raise a false fire alarm."""
+    bin_instance = make_bin("HOT")
+    simulator = BinSimulator(bin_instance)
+
+    bin_instance.current_fill_level = 50.0
+    simulator._simulate_temperature()
+
+    assert bin_instance.temperature < FIRE_RISK_TEMPERATURE
+
+
+def test_hot_bin_stays_within_the_contracted_range():
+    """Even at capacity a hot bin reports a believable temperature.
+
+    A HOT bin is extreme but valid data and must reach the detector; only a
+    SPIKE bin should be rejected as impossible.
+    """
+    bin_instance = make_bin("HOT")
+    simulator = BinSimulator(bin_instance)
+
+    bin_instance.current_fill_level = bin_instance.capacity
+    simulator._simulate_temperature()
+
+    assert bin_instance.temperature == settings.TEMP_FIRE_MAX
+    assert bin_instance.temperature < IMPOSSIBLE_TEMPERATURE
+
+
+def test_healthy_bin_never_reaches_fire_risk_temperature():
+    """A healthy bin stays in the ambient band no matter how full it gets."""
+    bin_instance = make_bin()
+    bin_instance.current_fill_level = 99.0
+    simulator = BinSimulator(bin_instance)
+
+    tick(simulator, count=200)
+
+    assert settings.TEMP_NORMAL_MIN <= bin_instance.temperature
+    assert bin_instance.temperature <= settings.TEMP_NORMAL_MAX
+
+
+# --------------------------------------------------------------------------
+# UNCOLLECTED - SLA breach detection
+# --------------------------------------------------------------------------
+
+
+def test_uncollected_bin_is_never_emptied():
+    """A bin the truck never comes for stays full, and breaches its SLA.
+
+    Every healthy bin is emptied well inside the two hours the SLA allows, so
+    without this fault the breach rule could never be observed firing.
+    """
+    bin_instance = make_bin("UNCOLLECTED")
+    bin_instance.current_fill_level = bin_instance.capacity
+    simulator = BinSimulator(bin_instance)
+
+    tick(simulator, count=500)
+
+    assert bin_instance.current_fill_level == bin_instance.capacity
+
+
+def test_healthy_bin_is_eventually_collected():
+    """The comparison case: a healthy bin does get emptied.
+
+    Guards the SLA test above against passing for the wrong reason - a change
+    that stopped every bin being collected would otherwise look fine.
+    """
+    bin_instance = make_bin()
+    bin_instance.current_fill_level = bin_instance.capacity
+    simulator = BinSimulator(bin_instance)
+
+    for _ in range(2000):
+        tick(simulator)
+        if bin_instance.current_fill_level == 0:
+            return
+
+    pytest.fail("a healthy bin was never collected")
+
+
+# --------------------------------------------------------------------------
+# JUMP - abnormal jump detection
+# --------------------------------------------------------------------------
+
+
+def test_jump_bin_moves_far_more_than_a_healthy_one():
+    """A jumping bin gains a suspicious amount between two readings."""
+    jumping = make_bin("JUMP")
+    healthy = make_bin()
+
+    BinSimulator(jumping)._simulate_fill()
+    BinSimulator(healthy)._simulate_fill()
+
+    assert jumping.current_fill_level > healthy.current_fill_level * 10
+
+
+def test_jump_bin_stays_a_believable_level():
+    """The jump is large but legal, so a range check alone will not catch it.
+
+    This is the point of the fault: it has to be found by comparing against the
+    previous reading, not by validating one event in isolation.
+    """
+    bin_instance = make_bin("JUMP")
+    simulator = BinSimulator(bin_instance)
+
+    tick(simulator, count=10)
+
+    assert 0 <= bin_instance.current_fill_level <= bin_instance.capacity

--- a/services/data-simulator/tests/simulator/test_faults.py
+++ b/services/data-simulator/tests/simulator/test_faults.py
@@ -79,13 +79,43 @@ def test_assign_fault_modes_can_be_disabled():
 # --------------------------------------------------------------------------
 
 
+def test_silent_bin_reports_before_it_dies():
+    """A silent bin is heard from first, then stops.
+
+    It has to report at least once. Dead-device detection arms a timer when a
+    bin reports and fires when that timer expires, so a bin that has never been
+    heard from cannot be reported as lost - nothing downstream knows it exists,
+    and the alert would never fire on a freshly started stack.
+    """
+    simulator = BinSimulator(make_bin("SILENT"))
+
+    first = simulator._next_payload()
+
+    assert first is not None
+    assert first["bin_id"] == "bin_1"
+
+
+def test_silent_bin_goes_quiet_after_its_first_readings():
+    """Having reported, it then stops - which is what detection notices."""
+    simulator = BinSimulator(make_bin("SILENT"))
+
+    published = [
+        simulator._next_payload()
+        for _ in range(settings.SILENCE_AFTER_READINGS + 5)
+    ]
+
+    assert all(payload is not None for payload in published[: settings.SILENCE_AFTER_READINGS])
+    assert all(payload is None for payload in published[settings.SILENCE_AFTER_READINGS :])
+
+
 @pytest.mark.asyncio
 @patch("src.simulator.bin_simulator.kafka_client")
 @patch("src.simulator.bin_simulator.asyncio.sleep")
-async def test_silent_bin_publishes_nothing(mock_sleep, mock_kafka_client):
-    """A silent bin stops sending, which is what dead-device detection sees."""
+async def test_a_dead_bin_publishes_nothing(mock_sleep, mock_kafka_client):
+    """Once silent, the loop runs but sends nothing at all."""
     mock_kafka_client.send_telemetry = AsyncMock()
     simulator = BinSimulator(make_bin("SILENT"))
+    simulator._published = settings.SILENCE_AFTER_READINGS
     simulator._running = True
 
     async def stop(*args, **kwargs):

--- a/services/data-simulator/tests/simulator/test_simulation_manager.py
+++ b/services/data-simulator/tests/simulator/test_simulation_manager.py
@@ -1,13 +1,31 @@
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
-from src.simulator.simulation_manager import SimulationManager
+from src.simulator.simulation_manager import SchemaNotReadyError, SimulationManager
 from src.models.bin import Bin
 from src.database import SmartBin
 from sqlalchemy.sql.expression import Select
 
+# Captured before the autouse fixture below replaces it, so the tests that
+# exercise the check itself call the real implementation rather than the mock
+# standing in for it everywhere else.
+REAL_REQUIRE_SCHEMA = SimulationManager.require_schema
+
 @pytest.fixture
 def sim_manager():
     return SimulationManager()
+
+
+@pytest.fixture(autouse=True)
+def migrated_database():
+    """Assume the schema exists, unless a test says otherwise.
+
+    `initialize()` checks the table is present before reading it, which is real
+    I/O against the engine. These tests mock the session, not the engine.
+    """
+    with patch.object(
+        SimulationManager, "require_schema", new=AsyncMock()
+    ) as check:
+        yield check
 
 @pytest.fixture
 def bin_instance():
@@ -200,3 +218,67 @@ def test_simulators_property(sim_manager):
 
     assert sim_manager.simulators is sim_manager._simulators
     assert sim_manager.simulators["bin_1"] is mock_simulator
+
+
+@pytest.mark.asyncio
+async def test_missing_schema_raises_an_actionable_error(sim_manager, migrated_database):
+    """An unmigrated database is answered, not stack-traced.
+
+    Migrations are a deliberate manual step, so starting against an unmigrated
+    database is a routine mistake. Letting the driver's own error escape gives
+    a thirty-line traceback with the one useful line at the bottom and no hint
+    of what to run.
+    """
+    migrated_database.side_effect = SchemaNotReadyError(
+        "The 'smart_bins' table does not exist. "
+        "Run: alembic upgrade head"
+    )
+
+    with pytest.raises(SchemaNotReadyError) as error:
+        await sim_manager.initialize()
+
+    assert "smart_bins" in str(error.value)
+    assert "alembic upgrade head" in str(error.value)
+
+
+@pytest.mark.asyncio
+@patch("src.simulator.simulation_manager.engine")
+async def test_require_schema_passes_when_the_table_exists(mock_engine, sim_manager):
+    """The happy path does not raise."""
+    connection = AsyncMock()
+    connection.run_sync.return_value = True
+    mock_engine.connect.return_value.__aenter__.return_value = connection
+
+    await REAL_REQUIRE_SCHEMA(sim_manager)
+
+
+@pytest.mark.asyncio
+@patch("src.simulator.simulation_manager.engine")
+async def test_require_schema_names_the_commands_to_run(mock_engine, sim_manager):
+    """The error carries the fix, not just the diagnosis."""
+    connection = AsyncMock()
+    connection.run_sync.return_value = False
+    mock_engine.connect.return_value.__aenter__.return_value = connection
+
+    with pytest.raises(SchemaNotReadyError) as error:
+        await REAL_REQUIRE_SCHEMA(sim_manager)
+
+    message = str(error.value)
+    assert "alembic upgrade head" in message
+    assert "seed.py" in message
+
+
+@pytest.mark.asyncio
+@patch("src.simulator.simulation_manager.AsyncSessionLocal")
+async def test_an_unseeded_database_says_so(mock_session_maker, sim_manager, caplog):
+    """Zero bins is not fatal, but silence reads as a broken simulator."""
+    mock_session = AsyncMock()
+    mock_session_maker.return_value.__aenter__.return_value = mock_session
+    mock_result = MagicMock()
+    mock_result.scalars().all.return_value = []
+    mock_session.execute.return_value = mock_result
+
+    await sim_manager.initialize()
+
+    assert "No ACTIVE bins found" in caplog.text
+    assert "seed.py" in caplog.text

--- a/services/data-simulator/tests/test_contract.py
+++ b/services/data-simulator/tests/test_contract.py
@@ -1,0 +1,95 @@
+"""Assert the published payload matches the shared telemetry contract.
+
+`contracts/telemetry-v1.json` at the repository root is the agreement between
+this service and every consumer of `smartbin-telemetry-v1`. The consumer builds
+a fixed schema from that file, which means a field renamed here and not there
+does not raise anything: the consumer reads nulls for the renamed column, every
+rule that depends on it silently stops matching, and no job fails. This test is
+the half of that agreement the producer is responsible for.
+
+The checks are deliberately name-and-type only, with no JSON Schema library. The
+failure this guards against is a field disappearing or changing shape; the value
+ranges in the contract are enforced by the consumer, which rejects out-of-range
+readings to a dead-letter topic rather than trusting the producer.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.models.bin import Bin
+
+CONTRACT_PATH = (
+    Path(__file__).resolve().parents[3] / "contracts" / "telemetry-v1.json"
+)
+
+JSON_TYPE_CHECKS = {
+    "string": str,
+    "number": (int, float),
+}
+
+
+@pytest.fixture(scope="module")
+def contract():
+    """The parsed telemetry contract."""
+    return json.loads(CONTRACT_PATH.read_text())
+
+
+@pytest.fixture
+def payload():
+    """A payload from a bin carrying non-default values in every field."""
+    bin_instance = Bin("bin_1", 240.0, 17.4, 78.5, "NORTH")
+    bin_instance.current_fill_level = 123.456
+    bin_instance.battery_level = 80.456
+    bin_instance.temperature = 71.5
+    return bin_instance.to_payload()
+
+
+def test_contract_file_exists():
+    """The shared contract is where both services expect to find it."""
+    assert CONTRACT_PATH.is_file(), f"missing contract at {CONTRACT_PATH}"
+
+
+def test_payload_fields_match_the_contract_exactly(contract, payload):
+    """The payload has every contracted field and no field the contract omits."""
+    assert set(payload) == set(contract["properties"])
+    # required and properties must not drift apart within the contract itself
+    assert set(contract["required"]) == set(contract["properties"])
+
+
+def test_payload_field_types_match_the_contract(contract, payload):
+    """Every payload value has the JSON type the contract declares."""
+    for field, spec in contract["properties"].items():
+        expected = JSON_TYPE_CHECKS[spec["type"]]
+        assert isinstance(payload[field], expected), (
+            f"{field} is {type(payload[field]).__name__}, "
+            f"contract says {spec['type']}"
+        )
+
+
+def test_payload_values_sit_inside_the_contracted_ranges(contract, payload):
+    """A routine payload is not itself rejected by the ranges we publish."""
+    for field, spec in contract["properties"].items():
+        value = payload[field]
+        if "minimum" in spec:
+            assert value >= spec["minimum"], f"{field}={value} below minimum"
+        if "maximum" in spec:
+            assert value <= spec["maximum"], f"{field}={value} above maximum"
+        if "exclusiveMinimum" in spec:
+            assert value > spec["exclusiveMinimum"], f"{field}={value} too low"
+
+
+def test_contract_permits_a_hot_bin_but_not_an_impossible_one(contract):
+    """The temperature range admits fire-risk readings and rejects sensor faults.
+
+    Fire risk is detected above 70 C, so if the contract capped temperature at
+    ambient the consumer would reject exactly the readings the rule exists to
+    catch. The SPIKE fault must still fall outside.
+    """
+    from src.simulator.bin_simulator import IMPOSSIBLE_TEMPERATURE
+
+    temperature = contract["properties"]["temperature"]
+
+    assert temperature["maximum"] > 70
+    assert IMPOSSIBLE_TEMPERATURE > temperature["maximum"]

--- a/services/data-simulator/tests/test_main.py
+++ b/services/data-simulator/tests/test_main.py
@@ -5,6 +5,13 @@ import pytest
 
 from src.main import main
 
+# NOTE: import SchemaNotReadyError the same way main.py does
+# (`from simulator.simulation_manager import ...`). Because `src/` has no
+# __init__.py, `simulator.simulation_manager.SchemaNotReadyError` and
+# `src.simulator.simulation_manager.SchemaNotReadyError` are two distinct class
+# objects, and an `except` against the wrong one never matches.
+from simulator.simulation_manager import SchemaNotReadyError
+
 
 @pytest.mark.asyncio
 @patch("src.main.asyncio.Event")
@@ -51,5 +58,86 @@ async def test_main_startup_and_clean_shutdown(
 
     # Cleanup sequence
     mock_manager.stop.assert_awaited_once()
+    mock_kafka_client.stop.assert_awaited_once()
+    mock_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@patch("src.main.engine")
+@patch("src.main.SimulationManager")
+@patch("src.main.kafka_client")
+async def test_failed_startup_still_releases_the_kafka_producer(
+    mock_kafka_client,
+    mock_simulation_manager_cls,
+    mock_engine,
+):
+    """Cleanup runs even when startup fails.
+
+    The cleanup block used to sit after the shutdown wait, which never happens
+    if startup raises. A crash therefore left the producer open and the process
+    died complaining about an unclosed AIOKafkaProducer - burying the real
+    cause under a warning about a symptom.
+    """
+    mock_manager = AsyncMock()
+    mock_manager.initialize.side_effect = SchemaNotReadyError("run alembic")
+    mock_simulation_manager_cls.return_value = mock_manager
+
+    mock_kafka_client.start = AsyncMock()
+    mock_kafka_client.stop = AsyncMock()
+    mock_engine.dispose = AsyncMock()
+
+    exit_code = await main()
+
+    mock_kafka_client.stop.assert_awaited_once()
+    mock_engine.dispose.assert_awaited_once()
+    assert exit_code == 1
+
+
+@pytest.mark.asyncio
+@patch("src.main.engine")
+@patch("src.main.SimulationManager")
+@patch("src.main.kafka_client")
+async def test_missing_schema_is_reported_without_a_traceback(
+    mock_kafka_client,
+    mock_simulation_manager_cls,
+    mock_engine,
+    caplog,
+):
+    """The operator is told what to run, not shown a stack trace."""
+    mock_manager = AsyncMock()
+    mock_manager.initialize.side_effect = SchemaNotReadyError(
+        "The 'smart_bins' table does not exist. Run: alembic upgrade head"
+    )
+    mock_simulation_manager_cls.return_value = mock_manager
+
+    mock_kafka_client.start = AsyncMock()
+    mock_kafka_client.stop = AsyncMock()
+    mock_engine.dispose = AsyncMock()
+
+    exit_code = await main()
+
+    assert exit_code == 1
+    assert "alembic upgrade head" in caplog.text
+    assert "Traceback" not in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("src.main.engine")
+@patch("src.main.kafka_client")
+async def test_shutdown_continues_after_a_failing_step(mock_kafka_client, mock_engine):
+    """One failing step must not skip the ones after it.
+
+    A producer left open because the manager stopped badly is a leak the logs
+    would then blame on the wrong component.
+    """
+    from src.main import shutdown
+
+    manager = AsyncMock()
+    manager.stop.side_effect = RuntimeError("manager is wedged")
+    mock_kafka_client.stop = AsyncMock()
+    mock_engine.dispose = AsyncMock()
+
+    await shutdown(manager)
+
     mock_kafka_client.stop.assert_awaited_once()
     mock_engine.dispose.assert_awaited_once()

--- a/services/data-simulator/tests/test_migrations.py
+++ b/services/data-simulator/tests/test_migrations.py
@@ -1,5 +1,7 @@
 import asyncio
+import configparser
 import os
+from pathlib import Path
 
 import asyncpg
 import pytest
@@ -19,6 +21,37 @@ def test_migrations_have_one_linear_head():
         "0002_add_zone",
         "9b7a1e20a036",
     ]
+
+
+def test_migrations_are_not_silent():
+    """Alembic is configured to report the revisions it applies.
+
+    Without these sections an upgrade runs in total silence: no "Running
+    upgrade" line and no confirmation of which revision was applied. A migration
+    that silently did nothing then looks identical to one that worked, on the
+    one command whose whole job is changing the shape of the database.
+    """
+    parser = configparser.ConfigParser()
+    parser.read("alembic.ini")
+
+    for section in ("loggers", "handlers", "formatters", "logger_alembic"):
+        assert parser.has_section(section), f"alembic.ini lost [{section}]"
+
+    assert parser.get("logger_alembic", "level") == "INFO"
+
+
+def test_env_loads_the_logging_configuration():
+    """The ini sections are useless unless env.py actually applies them.
+
+    Configuring logging is opt-in: Alembic does not read those sections by
+    itself, so this is the other half of the same fix.
+    """
+    env = Path("alembic/env.py").read_text()
+
+    assert "fileConfig" in env
+    # Tearing down existing loggers would silence pytest's own logging partway
+    # through a run, since this file is executed by the integration test below.
+    assert "disable_existing_loggers=False" in env
 
 
 @pytest.mark.skipif(

--- a/services/data-simulator/tests/test_seed.py
+++ b/services/data-simulator/tests/test_seed.py
@@ -1,7 +1,13 @@
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from src.seed import HYDERABAD_CENTER, ZONE_OFFSETS, seed_db
+from src.seed import (
+    BIN_CAPACITIES,
+    HYDERABAD_CENTER,
+    MAX_BINS_PER_RUN,
+    ZONE_OFFSETS,
+    seed_db,
+)
 
 # NOTE: import SmartBin the same way seed.py does (`from database import ...`).
 # Because `src/` has no __init__.py, `database.SmartBin` and `src.database.SmartBin`
@@ -94,16 +100,43 @@ async def test_seed_clear_true_deletes_first(
 
 @pytest.mark.asyncio
 @patch("src.seed.create_async_engine")
-async def test_seed_over_500_is_rejected(mock_create_engine, capsys):
+async def test_seed_over_the_cap_is_rejected(mock_create_engine, capsys):
     """
-    Test the safety guard: requesting more than 500 bins is rejected early,
-    prints an error, and never creates a database engine nor session.
+    Test the safety guard: requesting more bins than the cap allows is rejected
+    early, prints an error, and never creates a database engine nor session.
     """
-    await seed_db(count=501, clear=False)
+    await seed_db(count=MAX_BINS_PER_RUN + 1, clear=False)
 
     captured = capsys.readouterr()
-    assert "cannot seed more than 500" in captured.out.lower()
+    assert f"cannot seed more than {MAX_BINS_PER_RUN}" in captured.out.lower()
     mock_create_engine.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("src.seed.async_sessionmaker")
+@patch("src.seed.create_async_engine")
+async def test_seed_uses_a_range_of_capacities(
+    mock_create_engine, mock_async_sessionmaker
+):
+    """
+    Test that seeded bins are not all the same size.
+    A single capacity would make the raw fill level and the fill percentage
+    numerically identical, hiding every percentage threshold downstream.
+    """
+    mock_engine = MagicMock()
+    mock_engine.dispose = AsyncMock()
+    mock_create_engine.return_value = mock_engine
+
+    mock_session = _build_session_mock()
+    _wire_session_factory(mock_async_sessionmaker, mock_session)
+
+    await seed_db(count=200, clear=False)
+
+    capacities = {
+        call_args.args[0].capacity for call_args in mock_session.add.call_args_list
+    }
+    assert capacities <= set(BIN_CAPACITIES)
+    assert len(capacities) > 1
 
 
 @pytest.mark.asyncio

--- a/services/stream-processor/.dockerignore
+++ b/services/stream-processor/.dockerignore
@@ -1,0 +1,6 @@
+**/.venv
+**/__pycache__
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+**/*.pyc

--- a/services/stream-processor/Dockerfile
+++ b/services/stream-processor/Dockerfile
@@ -4,12 +4,13 @@
 # The build context is the repository root, not this directory, so the shared
 # telemetry contract can be copied in. Both services build their view of the
 # payload from that one file.
-FROM python:3.11-slim AS base
+FROM python:3.11-slim-bookworm AS base
 
 WORKDIR /app
 
 # Spark runs on the JVM even when driven from Python, and local mode still
-# starts one in-process.
+# starts one in-process. Spark 3.5 supports Java 8, 11 and 17 - not 21 - which
+# is why the base image is pinned to bookworm; trixie dropped the 17 packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     openjdk-17-jre-headless \
     curl \
@@ -19,7 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONPATH=/app:/app/src
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+# JAVA_HOME is deliberately unset: Spark falls back to java on PATH, which
+# avoids hardcoding a path that differs between amd64 and arm64.
 
 COPY services/stream-processor/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/services/stream-processor/Dockerfile
+++ b/services/stream-processor/Dockerfile
@@ -4,7 +4,7 @@
 # The build context is the repository root, not this directory, so the shared
 # telemetry contract can be copied in. Both services build their view of the
 # payload from that one file.
-FROM python:3.12-slim AS base
+FROM python:3.11-slim AS base
 
 WORKDIR /app
 

--- a/services/stream-processor/Dockerfile
+++ b/services/stream-processor/Dockerfile
@@ -1,0 +1,73 @@
+# ===========================
+# Base Stage
+# ===========================
+# The build context is the repository root, not this directory, so the shared
+# telemetry contract can be copied in. Both services build their view of the
+# payload from that one file.
+FROM python:3.12-slim AS base
+
+WORKDIR /app
+
+# Spark runs on the JVM even when driven from Python, and local mode still
+# starts one in-process.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openjdk-17-jre-headless \
+    curl \
+    procps \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPATH=/app:/app/src
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+
+COPY services/stream-processor/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# The Kafka connector, baked in rather than resolved by --packages at submit
+# time. Resolving at submit time means the container needs Maven Central to
+# start, so a slow repository becomes a service that will not boot.
+#
+# These versions are not free choices: the connector must match the Spark
+# version exactly, and kafka-clients must match what that connector was built
+# against.
+ARG SPARK_VERSION=3.5.3
+ARG SCALA_VERSION=2.12
+ARG KAFKA_CLIENTS_VERSION=3.4.1
+ARG COMMONS_POOL2_VERSION=2.11.1
+
+RUN JARS=$(python -c "import pyspark, pathlib; print(pathlib.Path(pyspark.__file__).parent / 'jars')") && \
+    BASE=https://repo1.maven.org/maven2 && \
+    curl -fsSL -o "$JARS/spark-sql-kafka-0-10_${SCALA_VERSION}-${SPARK_VERSION}.jar" \
+      "$BASE/org/apache/spark/spark-sql-kafka-0-10_${SCALA_VERSION}/${SPARK_VERSION}/spark-sql-kafka-0-10_${SCALA_VERSION}-${SPARK_VERSION}.jar" && \
+    curl -fsSL -o "$JARS/spark-token-provider-kafka-0-10_${SCALA_VERSION}-${SPARK_VERSION}.jar" \
+      "$BASE/org/apache/spark/spark-token-provider-kafka-0-10_${SCALA_VERSION}/${SPARK_VERSION}/spark-token-provider-kafka-0-10_${SCALA_VERSION}-${SPARK_VERSION}.jar" && \
+    curl -fsSL -o "$JARS/kafka-clients-${KAFKA_CLIENTS_VERSION}.jar" \
+      "$BASE/org/apache/kafka/kafka-clients/${KAFKA_CLIENTS_VERSION}/kafka-clients-${KAFKA_CLIENTS_VERSION}.jar" && \
+    curl -fsSL -o "$JARS/commons-pool2-${COMMONS_POOL2_VERSION}.jar" \
+      "$BASE/org/apache/commons/commons-pool2/${COMMONS_POOL2_VERSION}/commons-pool2-${COMMONS_POOL2_VERSION}.jar"
+
+
+# ===========================
+# Test Stage
+# ===========================
+FROM base AS test
+
+COPY services/stream-processor/requirements-dev.txt .
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+COPY contracts/ ./contracts/
+COPY services/stream-processor/ .
+
+RUN pytest
+
+
+# ===========================
+# Runtime Stage
+# ===========================
+FROM base AS runtime
+
+COPY contracts/ ./contracts/
+COPY services/stream-processor/ .
+
+CMD ["python", "src/main.py"]

--- a/services/stream-processor/pytest.ini
+++ b/services/stream-processor/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+pythonpath = . src

--- a/services/stream-processor/requirements-dev.txt
+++ b/services/stream-processor/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+
+pytest
+pytest-asyncio
+pytest-cov
+ruff
+mypy

--- a/services/stream-processor/requirements-dev.txt
+++ b/services/stream-processor/requirements-dev.txt
@@ -5,3 +5,9 @@ pytest-asyncio
 pytest-cov
 ruff
 mypy
+
+# PySpark 3.5 supports Python up to 3.11, which is what the image and CI run.
+# On a machine that only has 3.12 the pandas UDF path fails importing distutils,
+# removed in that version; setuptools restores it so the suite can still be run
+# locally. Not a substitute for the supported version - it only covers this.
+setuptools

--- a/services/stream-processor/requirements.txt
+++ b/services/stream-processor/requirements.txt
@@ -1,0 +1,7 @@
+pyspark==3.5.3
+psycopg2-binary
+pandas
+pyarrow
+pydantic-settings
+python-dotenv
+colorlog

--- a/services/stream-processor/sql/schema.sql
+++ b/services/stream-processor/sql/schema.sql
@@ -129,18 +129,28 @@ CREATE INDEX IF NOT EXISTS zone_daily_trend_day_idx
 -- ---------------------------------------------------------------------------
 -- Every one of these is an aggregate of the three tables above, so the
 -- dashboard costs no streaming work of its own. A bin counts as active if it
--- has reported inside the offline threshold, which is the same 15 minutes the
+-- has reported inside the offline threshold, which is the same window the
 -- dead-device rule uses; anything older is what "offline" means here.
+--
+-- The placeholders below are filled in by sinks.apply_schema() from the same
+-- settings the detection rules read, so the dashboard and the alerts cannot
+-- disagree about what "critical" or "offline" means. Running this file through
+-- psql directly will not work for that reason - go through the service.
 CREATE OR REPLACE VIEW city_kpi AS
 SELECT
     (SELECT count(*) FROM bin_state_latest)                             AS total_bins,
     (SELECT count(*) FROM bin_state_latest
-      WHERE last_seen > now() - INTERVAL '15 minutes')                  AS active_bins,
+      WHERE last_seen > now() - {offline_minutes} * INTERVAL '1 minute')
+                                                                          AS active_bins,
     (SELECT count(*) FROM bin_state_latest
-      WHERE last_seen <= now() - INTERVAL '15 minutes')                 AS offline_bins,
-    (SELECT count(*) FROM bin_state_latest WHERE fill_pct >= 80)        AS critical_bins,
-    (SELECT count(*) FROM bin_state_latest WHERE fill_pct >= 95)        AS overflowing_bins,
-    (SELECT count(*) FROM bin_state_latest WHERE battery_level < 20)    AS low_battery_bins,
+      WHERE last_seen <= now() - {offline_minutes} * INTERVAL '1 minute')
+                                                                          AS offline_bins,
+    (SELECT count(*) FROM bin_state_latest WHERE fill_pct >= {critical_fill_pct})
+                                                                          AS critical_bins,
+    (SELECT count(*) FROM bin_state_latest WHERE fill_pct >= {overflow_fill_pct})
+                                                                          AS overflowing_bins,
+    (SELECT count(*) FROM bin_state_latest WHERE battery_level < {low_battery_pct})
+                                                                          AS low_battery_bins,
     (SELECT round(avg(fill_pct)::numeric, 2) FROM bin_state_latest)     AS avg_fill_pct,
     (SELECT round(avg(temperature)::numeric, 2) FROM bin_state_latest)  AS avg_temperature,
     (SELECT count(*) FROM bin_alerts
@@ -152,7 +162,7 @@ SELECT
       WHERE alert_type = 'FIRE_RISK'
         AND fired_at >= date_trunc('day', now()))                       AS fire_risk_today,
     (SELECT count(*) FROM bin_alerts
-      WHERE alert_type = 'SLA_BREACH'
+      WHERE alert_type LIKE 'SLA_BREACH%'
         AND fired_at >= date_trunc('day', now()))                       AS sla_breaches_today,
     -- Bins reporting at least one unusable sensor. These are still counted in
     -- every figure above, which is the point: a bin with a dead thermometer is
@@ -167,7 +177,7 @@ SELECT
     zone,
     count(*)                                  AS bins,
     round(avg(fill_pct)::numeric, 2)          AS avg_fill_pct,
-    count(*) FILTER (WHERE fill_pct >= 80)    AS critical_bins,
+    count(*) FILTER (WHERE fill_pct >= {critical_fill_pct}) AS critical_bins,
     round(avg(temperature)::numeric, 2)       AS avg_temperature
 FROM bin_state_latest
 GROUP BY zone

--- a/services/stream-processor/sql/schema.sql
+++ b/services/stream-processor/sql/schema.sql
@@ -1,0 +1,164 @@
+-- Analytical tables written by the stream processor and read by the APIs.
+--
+-- This file is the storage contract. It is applied at startup and is written to
+-- be safe to re-run, so a restart never destroys accumulated history.
+--
+-- These tables are deliberately NOT part of the data-simulator Alembic chain.
+-- That chain describes the simulator's own operational table, and the two are
+-- owned by different services with different lifecycles; folding analytical
+-- output into it would make either service unable to migrate without the other.
+--
+-- Every table carries a primary key that a re-run of the same batch collides
+-- with. Spark re-runs a batch after a failed write, so writes have to be safe to
+-- repeat: an append-only table would silently double-count on every retry.
+
+-- ---------------------------------------------------------------------------
+-- bin_alerts - one row per alert or collection event
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS bin_alerts (
+    bin_id        TEXT             NOT NULL,
+    zone          TEXT             NOT NULL,
+    alert_type    TEXT             NOT NULL,
+    severity      TEXT             NOT NULL,
+    fired_at      TIMESTAMPTZ      NOT NULL,
+    fill_pct      DOUBLE PRECISION,
+    temperature   DOUBLE PRECISION,
+    battery_level DOUBLE PRECISION,
+    detail        TEXT,
+    -- The natural key of an alert. Re-processing a batch produces the identical
+    -- row, which is then discarded rather than duplicated.
+    PRIMARY KEY (bin_id, alert_type, fired_at)
+);
+
+CREATE INDEX IF NOT EXISTS bin_alerts_fired_at_idx
+    ON bin_alerts (fired_at DESC);
+CREATE INDEX IF NOT EXISTS bin_alerts_type_fired_at_idx
+    ON bin_alerts (alert_type, fired_at DESC);
+CREATE INDEX IF NOT EXISTS bin_alerts_zone_idx
+    ON bin_alerts (zone, fired_at DESC);
+
+-- ---------------------------------------------------------------------------
+-- bin_state_latest - the current state of every bin, one row each
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS bin_state_latest (
+    bin_id                TEXT PRIMARY KEY,
+    zone                  TEXT             NOT NULL,
+    capacity              DOUBLE PRECISION,
+    current_fill_level    DOUBLE PRECISION,
+    fill_pct              DOUBLE PRECISION,
+    temperature           DOUBLE PRECISION,
+    battery_level         DOUBLE PRECISION,
+    latitude              DOUBLE PRECISION,
+    longitude             DOUBLE PRECISION,
+    -- Rate of change between the last two readings, and the projection built
+    -- from it. Null until a bin has reported twice.
+    fill_rate_pct_per_min DOUBLE PRECISION,
+    minutes_to_full       DOUBLE PRECISION,
+    last_seen             TIMESTAMPTZ      NOT NULL,
+    updated_at            TIMESTAMPTZ      NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS bin_state_latest_zone_idx
+    ON bin_state_latest (zone);
+CREATE INDEX IF NOT EXISTS bin_state_latest_last_seen_idx
+    ON bin_state_latest (last_seen DESC);
+CREATE INDEX IF NOT EXISTS bin_state_latest_fill_pct_idx
+    ON bin_state_latest (fill_pct DESC);
+
+-- ---------------------------------------------------------------------------
+-- zone_metrics_5m - one zone over one five-minute window
+-- ---------------------------------------------------------------------------
+-- Hourly, daily, weekly and monthly figures are all SQL rollups of this table,
+-- so streaming never has to hold more than five minutes of aggregate state.
+CREATE TABLE IF NOT EXISTS zone_metrics_5m (
+    window_start      TIMESTAMPTZ      NOT NULL,
+    window_end        TIMESTAMPTZ      NOT NULL,
+    zone              TEXT             NOT NULL,
+    bins_reporting    INTEGER          NOT NULL,
+    reading_count     BIGINT           NOT NULL,
+    avg_fill_pct      DOUBLE PRECISION,
+    max_fill_pct      DOUBLE PRECISION,
+    avg_temperature   DOUBLE PRECISION,
+    max_temperature   DOUBLE PRECISION,
+    critical_readings BIGINT           NOT NULL DEFAULT 0,
+    overflow_readings BIGINT           NOT NULL DEFAULT 0,
+    PRIMARY KEY (window_start, zone)
+);
+
+CREATE INDEX IF NOT EXISTS zone_metrics_5m_window_idx
+    ON zone_metrics_5m (window_start DESC);
+
+-- ---------------------------------------------------------------------------
+-- Nightly rollups - written by the batch job, not by any streaming query
+-- ---------------------------------------------------------------------------
+-- When waste is generated fastest, by zone and hour of day.
+CREATE TABLE IF NOT EXISTS zone_hourly_profile (
+    zone                   TEXT             NOT NULL,
+    hour_of_day            SMALLINT         NOT NULL,
+    avg_fill_rate_pct_hour DOUBLE PRECISION,
+    avg_fill_pct           DOUBLE PRECISION,
+    reading_count          BIGINT,
+    computed_at            TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    PRIMARY KEY (zone, hour_of_day)
+);
+
+-- Longer-range trends, one row per zone per day.
+CREATE TABLE IF NOT EXISTS zone_daily_trend (
+    zone                   TEXT             NOT NULL,
+    day                    DATE             NOT NULL,
+    avg_fill_pct           DOUBLE PRECISION,
+    max_fill_pct           DOUBLE PRECISION,
+    avg_temperature        DOUBLE PRECISION,
+    avg_fill_rate_pct_hour DOUBLE PRECISION,
+    bins_reporting         INTEGER,
+    collections            BIGINT,
+    computed_at            TIMESTAMPTZ      NOT NULL DEFAULT now(),
+    PRIMARY KEY (zone, day)
+);
+
+CREATE INDEX IF NOT EXISTS zone_daily_trend_day_idx
+    ON zone_daily_trend (day DESC);
+
+-- ---------------------------------------------------------------------------
+-- city_kpi - the dashboard headline numbers
+-- ---------------------------------------------------------------------------
+-- Every one of these is an aggregate of the three tables above, so the
+-- dashboard costs no streaming work of its own. A bin counts as active if it
+-- has reported inside the offline threshold, which is the same 15 minutes the
+-- dead-device rule uses; anything older is what "offline" means here.
+CREATE OR REPLACE VIEW city_kpi AS
+SELECT
+    (SELECT count(*) FROM bin_state_latest)                             AS total_bins,
+    (SELECT count(*) FROM bin_state_latest
+      WHERE last_seen > now() - INTERVAL '15 minutes')                  AS active_bins,
+    (SELECT count(*) FROM bin_state_latest
+      WHERE last_seen <= now() - INTERVAL '15 minutes')                 AS offline_bins,
+    (SELECT count(*) FROM bin_state_latest WHERE fill_pct >= 80)        AS critical_bins,
+    (SELECT count(*) FROM bin_state_latest WHERE fill_pct >= 95)        AS overflowing_bins,
+    (SELECT count(*) FROM bin_state_latest WHERE battery_level < 20)    AS low_battery_bins,
+    (SELECT round(avg(fill_pct)::numeric, 2) FROM bin_state_latest)     AS avg_fill_pct,
+    (SELECT round(avg(temperature)::numeric, 2) FROM bin_state_latest)  AS avg_temperature,
+    (SELECT count(*) FROM bin_alerts
+      WHERE fired_at >= date_trunc('day', now()))                       AS alerts_today,
+    (SELECT count(*) FROM bin_alerts
+      WHERE alert_type = 'COLLECTED'
+        AND fired_at >= date_trunc('day', now()))                       AS collections_today,
+    (SELECT count(*) FROM bin_alerts
+      WHERE alert_type = 'FIRE_RISK'
+        AND fired_at >= date_trunc('day', now()))                       AS fire_risk_today,
+    (SELECT count(*) FROM bin_alerts
+      WHERE alert_type = 'SLA_BREACH'
+        AND fired_at >= date_trunc('day', now()))                       AS sla_breaches_today,
+    (SELECT count(DISTINCT zone) FROM bin_state_latest)                 AS zones_covered;
+
+-- The busiest zones, by how full their bins currently are.
+CREATE OR REPLACE VIEW zone_leaderboard AS
+SELECT
+    zone,
+    count(*)                                  AS bins,
+    round(avg(fill_pct)::numeric, 2)          AS avg_fill_pct,
+    count(*) FILTER (WHERE fill_pct >= 80)    AS critical_bins,
+    round(avg(temperature)::numeric, 2)       AS avg_temperature
+FROM bin_state_latest
+GROUP BY zone
+ORDER BY avg_fill_pct DESC;

--- a/services/stream-processor/sql/schema.sql
+++ b/services/stream-processor/sql/schema.sql
@@ -54,6 +54,11 @@ CREATE TABLE IF NOT EXISTS bin_state_latest (
     -- from it. Null until a bin has reported twice.
     fill_rate_pct_per_min DOUBLE PRECISION,
     minutes_to_full       DOUBLE PRECISION,
+    -- Which of this bin's sensors are reporting values that cannot be true, or
+    -- null when they are all healthy. The readings themselves are nulled above
+    -- rather than discarded, so a bin with one dead sensor stays visible here
+    -- instead of vanishing from monitoring entirely.
+    sensor_faults         TEXT,
     last_seen             TIMESTAMPTZ      NOT NULL,
     updated_at            TIMESTAMPTZ      NOT NULL DEFAULT now()
 );
@@ -149,6 +154,11 @@ SELECT
     (SELECT count(*) FROM bin_alerts
       WHERE alert_type = 'SLA_BREACH'
         AND fired_at >= date_trunc('day', now()))                       AS sla_breaches_today,
+    -- Bins reporting at least one unusable sensor. These are still counted in
+    -- every figure above, which is the point: a bin with a dead thermometer is
+    -- still a bin, and used to disappear from all of them.
+    (SELECT count(*) FROM bin_state_latest
+      WHERE sensor_faults IS NOT NULL)                                  AS faulty_sensor_bins,
     (SELECT count(DISTINCT zone) FROM bin_state_latest)                 AS zones_covered;
 
 -- The busiest zones, by how full their bins currently are.

--- a/services/stream-processor/src/batch/rollups.py
+++ b/services/stream-processor/src/batch/rollups.py
@@ -1,0 +1,195 @@
+"""The nightly job - peak hours and longer-range trends.
+
+Two of the client's questions ask when waste is generated fastest and how it
+changes across weeks and seasons. Neither is a real-time question, and neither
+should cost streaming state: holding a month of history in a streaming query is
+something Spark does badly, and there is no reason to, because the history is
+already on disk.
+
+So this is a plain batch job over the Parquet the cleaning query writes. It runs
+once a night against data that is already there, which means it cannot block
+anything and cannot lose anything by failing - the next run recomputes the same
+answer from the same files.
+
+Collections are derived from the history here rather than read back from the
+alerts table. The rate of change between consecutive readings is already being
+computed for the fill rate, and a collection is a large negative one, so the
+number costs nothing extra and the job needs no read path into PostgreSQL.
+"""
+
+import logging
+import sys
+
+from pyspark.sql import DataFrame, SparkSession, Window
+from pyspark.sql.functions import (
+    avg,
+    col,
+    count,
+    countDistinct,
+    hour,
+    lag,
+    lit,
+    max as spark_max,
+    sum as spark_sum,
+    to_date,
+    when,
+)
+
+from config import get_settings
+from logging_config import setup_logging
+from schema import EVENT_TIME_COLUMN
+from session import build_session
+from sinks import write_batch
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+SECONDS_PER_HOUR = 3600.0
+
+HOURLY_TABLE = "zone_hourly_profile"
+HOURLY_COLUMNS = [
+    "zone",
+    "hour_of_day",
+    "avg_fill_rate_pct_hour",
+    "avg_fill_pct",
+    "reading_count",
+]
+
+DAILY_TABLE = "zone_daily_trend"
+DAILY_COLUMNS = [
+    "zone",
+    "day",
+    "avg_fill_pct",
+    "max_fill_pct",
+    "avg_temperature",
+    "avg_fill_rate_pct_hour",
+    "bins_reporting",
+    "collections",
+]
+
+
+def load_history(session: SparkSession) -> DataFrame:
+    """Read the clean event history written by the streaming pipeline."""
+    return session.read.parquet(settings.PARQUET_PATH)
+
+
+def with_fill_rate(events: DataFrame) -> DataFrame:
+    """
+    Attach the rate of change between each reading and the one before it.
+
+    A window function over the history, partitioned by bin so one bin's readings
+    are never compared against another's, and ordered by event time so
+    "previous" means what it says.
+
+    Two derived columns come out of the same comparison: how fast the bin was
+    filling, and whether it was emptied. Rates are expressed per hour rather than
+    per reading so the number does not change meaning when the reporting
+    interval is retuned.
+    """
+    previous = Window.partitionBy("bin_id").orderBy(EVENT_TIME_COLUMN)
+
+    with_previous = events.withColumn(
+        "prev_fill_pct", lag("fill_pct").over(previous)
+    ).withColumn("prev_event_time", lag(EVENT_TIME_COLUMN).over(previous))
+
+    elapsed_hours = (
+        col(EVENT_TIME_COLUMN).cast("double") - col("prev_event_time").cast("double")
+    ) / SECONDS_PER_HOUR
+
+    return (
+        with_previous.withColumn("elapsed_hours", elapsed_hours)
+        .withColumn(
+            "fill_rate_pct_hour",
+            # Only rises count towards a fill rate. A drop is the bin being
+            # emptied, and averaging that in would report zones as filling more
+            # slowly the more often they are collected - backwards.
+            when(
+                (col("elapsed_hours") > 0)
+                & (col("fill_pct") > col("prev_fill_pct")),
+                (col("fill_pct") - col("prev_fill_pct")) / col("elapsed_hours"),
+            ),
+        )
+        .withColumn(
+            "collected",
+            when(
+                (col("prev_fill_pct") >= settings.COLLECTION_DROP_FROM_PCT)
+                & (col("fill_pct") < settings.COLLECTION_DROP_TO_PCT),
+                lit(1),
+            ).otherwise(lit(0)),
+        )
+    )
+
+
+def hourly_profile(rated: DataFrame) -> DataFrame:
+    """
+    When each zone generates waste fastest, by hour of day.
+
+    Averaged across every day in the history, so this describes the shape of a
+    typical day rather than any particular one.
+    """
+    return (
+        rated.groupBy("zone", hour(col(EVENT_TIME_COLUMN)).alias("hour_of_day"))
+        .agg(
+            avg("fill_rate_pct_hour").alias("avg_fill_rate_pct_hour"),
+            avg("fill_pct").alias("avg_fill_pct"),
+            count("*").alias("reading_count"),
+        )
+        .select(*HOURLY_COLUMNS)
+    )
+
+
+def daily_trend(rated: DataFrame) -> DataFrame:
+    """One row per zone per day, for week-over-week and seasonal comparison."""
+    return (
+        rated.groupBy("zone", to_date(col(EVENT_TIME_COLUMN)).alias("day"))
+        .agg(
+            avg("fill_pct").alias("avg_fill_pct"),
+            spark_max("fill_pct").alias("max_fill_pct"),
+            avg("temperature").alias("avg_temperature"),
+            avg("fill_rate_pct_hour").alias("avg_fill_rate_pct_hour"),
+            countDistinct("bin_id").alias("bins_reporting"),
+            spark_sum("collected").alias("collections"),
+        )
+        .select(*DAILY_COLUMNS)
+    )
+
+
+def main() -> None:
+    setup_logging()
+    logger.info("Starting nightly rollups over %s", settings.PARQUET_PATH)
+
+    session = build_session()
+
+    try:
+        history = load_history(session)
+    except Exception:
+        # Nothing has been written yet. Not a failure worth waking anyone for -
+        # the next run picks it up once the streaming pipeline has produced
+        # something to roll up.
+        logger.warning(
+            "No history at %s yet; nothing to roll up", settings.PARQUET_PATH
+        )
+        session.stop()
+        return
+
+    # Read once and reused by both rollups; without this the whole history is
+    # scanned and the window function recomputed for each.
+    rated = with_fill_rate(history).persist()
+
+    try:
+        hourly = hourly_profile(rated)
+        write_batch(hourly, HOURLY_TABLE, HOURLY_COLUMNS, ["zone", "hour_of_day"], "upsert")
+        logger.info("Wrote %s", HOURLY_TABLE)
+
+        daily = daily_trend(rated)
+        write_batch(daily, DAILY_TABLE, DAILY_COLUMNS, ["zone", "day"], "upsert")
+        logger.info("Wrote %s", DAILY_TABLE)
+    finally:
+        rated.unpersist()
+        session.stop()
+
+    logger.info("Nightly rollups complete")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/stream-processor/src/batch/rollups.py
+++ b/services/stream-processor/src/batch/rollups.py
@@ -1,4 +1,4 @@
-"""The nightly job - peak hours and longer-range trends.
+"""The rollup job - peak hours and longer-range trends.
 
 Two of the client's questions ask when waste is generated fastest and how it
 changes across weeks and seasons. Neither is a real-time question, and neither
@@ -7,7 +7,7 @@ something Spark does badly, and there is no reason to, because the history is
 already on disk.
 
 So this is a plain batch job over the Parquet the cleaning query writes. It runs
-once a night against data that is already there, which means it cannot block
+on a schedule against data that is already there, which means it cannot block
 anything and cannot lose anything by failing - the next run recomputes the same
 answer from the same files.
 
@@ -19,6 +19,7 @@ number costs nothing extra and the job needs no read path into PostgreSQL.
 
 import logging
 import sys
+from pathlib import Path
 
 from pyspark.sql import DataFrame, SparkSession, Window
 from pyspark.sql.functions import (
@@ -156,41 +157,44 @@ def daily_trend(rated: DataFrame) -> DataFrame:
 
 def main() -> None:
     setup_logging()
-    logger.info("Starting nightly rollups over %s", settings.PARQUET_PATH)
+    logger.info("Starting rollups over %s", settings.PARQUET_PATH)
+
+    # Asked of the filesystem rather than inferred from an exception. Catching
+    # the read instead treated corruption, a permission problem and an
+    # incompatible schema as "nothing here yet" and exited successfully, so the
+    # analytical tables went stale with nothing to retry and nothing to alert
+    # on. An absent directory is the one condition that is genuinely fine.
+    if not Path(settings.PARQUET_PATH).exists():
+        logger.warning(
+            "No history at %s yet; nothing to roll up", settings.PARQUET_PATH
+        )
+        return
 
     # Its own UI port: this runs alongside the streaming application, which
     # already holds the default one.
     session = build_session(ui_port=settings.SPARK_BATCH_UI_PORT)
 
     try:
-        history = load_history(session)
-    except Exception:
-        # Nothing has been written yet. Not a failure worth waking anyone for -
-        # the next run picks it up once the streaming pipeline has produced
-        # something to roll up.
-        logger.warning(
-            "No history at %s yet; nothing to roll up", settings.PARQUET_PATH
-        )
-        session.stop()
-        return
+        # Read once and reused by both rollups; without this the whole history
+        # is scanned and the window function recomputed for each.
+        rated = with_fill_rate(load_history(session)).persist()
 
-    # Read once and reused by both rollups; without this the whole history is
-    # scanned and the window function recomputed for each.
-    rated = with_fill_rate(history).persist()
+        try:
+            hourly = hourly_profile(rated)
+            write_batch(
+                hourly, HOURLY_TABLE, HOURLY_COLUMNS, ["zone", "hour_of_day"], "upsert"
+            )
+            logger.info("Wrote %s", HOURLY_TABLE)
 
-    try:
-        hourly = hourly_profile(rated)
-        write_batch(hourly, HOURLY_TABLE, HOURLY_COLUMNS, ["zone", "hour_of_day"], "upsert")
-        logger.info("Wrote %s", HOURLY_TABLE)
-
-        daily = daily_trend(rated)
-        write_batch(daily, DAILY_TABLE, DAILY_COLUMNS, ["zone", "day"], "upsert")
-        logger.info("Wrote %s", DAILY_TABLE)
+            daily = daily_trend(rated)
+            write_batch(daily, DAILY_TABLE, DAILY_COLUMNS, ["zone", "day"], "upsert")
+            logger.info("Wrote %s", DAILY_TABLE)
+        finally:
+            rated.unpersist()
     finally:
-        rated.unpersist()
         session.stop()
 
-    logger.info("Nightly rollups complete")
+    logger.info("Rollups complete")
 
 
 if __name__ == "__main__":

--- a/services/stream-processor/src/batch/rollups.py
+++ b/services/stream-processor/src/batch/rollups.py
@@ -158,7 +158,9 @@ def main() -> None:
     setup_logging()
     logger.info("Starting nightly rollups over %s", settings.PARQUET_PATH)
 
-    session = build_session()
+    # Its own UI port: this runs alongside the streaming application, which
+    # already holds the default one.
+    session = build_session(ui_port=settings.SPARK_BATCH_UI_PORT)
 
     try:
         history = load_history(session)

--- a/services/stream-processor/src/config.py
+++ b/services/stream-processor/src/config.py
@@ -60,6 +60,18 @@ class Settings(BaseSettings):
     SPARK_MASTER: str = "local[*]"
     SPARK_APP_NAME: str = "smartbin-stream-processor"
 
+    # The Spark UI, which is the only place the streaming queries report what
+    # they are actually doing: input rate, batch duration, watermark position
+    # and state store size per query. Worth having published rather than left
+    # inside the container where nothing can reach it.
+    SPARK_UI_PORT: int = 4040
+
+    # The nightly batch job gets its own port. It runs alongside the streaming
+    # application, and without a separate port it silently lands on whatever
+    # Spark finds free after retrying - so the address changes run to run and
+    # the log carries a warning that reads like a fault.
+    SPARK_BATCH_UI_PORT: int = 4041
+
     # ---------------------------------------------------------------------
     # Detection thresholds
     #

--- a/services/stream-processor/src/config.py
+++ b/services/stream-processor/src/config.py
@@ -133,16 +133,18 @@ class Settings(BaseSettings):
         services build their view of the payload from one file.
         """
         service_root = Path(__file__).resolve().parents[1]
-        candidates = (
-            service_root / "contracts" / "telemetry-v1.json",
-            service_root.parents[1] / "contracts" / "telemetry-v1.json",
-        )
-        for candidate in candidates:
+
+        # Walk upwards rather than naming fixed candidates, because the layout
+        # differs: in the image the contract sits beside the service at /app,
+        # while in the repository it is two levels up at the root. Searching
+        # upwards covers both without either having to know about the other.
+        for base in (service_root, *service_root.parents):
+            candidate = base / "contracts" / "telemetry-v1.json"
             if candidate.is_file():
                 return candidate
+
         raise FileNotFoundError(
-            f"telemetry contract not found, looked in: "
-            f"{', '.join(str(c) for c in candidates)}"
+            f"telemetry contract not found searching upwards from {service_root}"
         )
 
     def checkpoint_for(self, query_name: str) -> str:

--- a/services/stream-processor/src/config.py
+++ b/services/stream-processor/src/config.py
@@ -1,0 +1,155 @@
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic import computed_field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """
+    Configuration for the stream processor.
+
+    Mirrors the data-simulator's settings module so both services are configured
+    the same way, and so a single .env file can drive the whole stack.
+    """
+
+    POSTGRES_HOST: str
+    POSTGRES_PORT: int
+    POSTGRES_DB: str
+    POSTGRES_USER: str
+    POSTGRES_PASSWORD: str
+
+    KAFKA_BOOTSTRAP_SERVERS: str
+    KAFKA_TOPIC: str = "smartbin-telemetry-v1"
+
+    # Messages that cannot be parsed, or that carry a reading no sensor could
+    # produce, are published here rather than dropped. A dropped message is
+    # invisible; a dead-lettered one can be counted and inspected.
+    KAFKA_DLQ_TOPIC: str = "smartbin-telemetry-dlq"
+
+    # Where the streaming queries keep their state. This is not a cache: it
+    # holds every SLA clock, every last-seen timestamp and every deduplication
+    # key. Deleting it does not reset a query, it erases the memory of the
+    # entire fleet. Each query gets its own subdirectory so one can be reset
+    # without disturbing the others.
+    CHECKPOINT_ROOT: str = "/data/checkpoints"
+
+    # The clean, deduplicated event history. Read by the nightly batch job, and
+    # the only place a question nobody has asked yet can still be answered from.
+    PARQUET_PATH: str = "/data/bin_events"
+
+    # Telemetry arrives every few seconds, so a ten second batch sees about two
+    # readings per bin. Shorter batches cost more database round trips and buy
+    # latency nobody asked for.
+    TRIGGER_INTERVAL: str = "10 seconds"
+
+    # Without a cap the first batch after any downtime tries to read the entire
+    # backlog at once and the job dies on memory. The cap turns a restart into a
+    # catch-up that completes over several batches.
+    MAX_OFFSETS_PER_TRIGGER: int = 100000
+
+    # How far out of order events may arrive before they are ignored. Also the
+    # window over which duplicates are detected.
+    WATERMARK: str = "10 minutes"
+
+    STARTING_OFFSETS: str = "latest"
+
+    # Local mode: one machine, no master and no workers. A thousand events a
+    # second does not need a cluster, and skipping it removes three containers
+    # and a network. Add the cluster when one machine measurably runs out.
+    SPARK_MASTER: str = "local[*]"
+    SPARK_APP_NAME: str = "smartbin-stream-processor"
+
+    # ---------------------------------------------------------------------
+    # Detection thresholds
+    #
+    # These are the client's rules, in one place, so the numbers a reviewer
+    # wants to check are not scattered through the query code.
+    # ---------------------------------------------------------------------
+
+    # A bin at or above this is on the collection list.
+    CRITICAL_FILL_PCT: float = 80.0
+
+    # At or above this it is overflowing, and on a much shorter clock.
+    OVERFLOW_FILL_PCT: float = 95.0
+
+    # Fire risk means hot AND nearly full. Either alone is not an emergency: a
+    # hot empty bin is a warm day, and a full cool bin is just a full bin.
+    FIRE_RISK_TEMP_C: float = 70.0
+    FIRE_RISK_FILL_PCT: float = 80.0
+
+    # Fire risk re-fires on this interval for as long as it stays true, unlike
+    # the alerts that fire once on entry. A fire does not stop being urgent
+    # because it was already reported.
+    FIRE_RISK_REPEAT_MINUTES: float = 5.0
+
+    LOW_BATTERY_PCT: float = 20.0
+
+    # Silent for this long and the device is treated as dead.
+    OFFLINE_AFTER_MINUTES: float = 15.0
+
+    # A collection is a large drop, not any drop. Requiring the bin to have been
+    # substantially full first separates a truck emptying it from sensor noise
+    # or a partial removal.
+    COLLECTION_DROP_FROM_PCT: float = 60.0
+    COLLECTION_DROP_TO_PCT: float = 20.0
+
+    # A rise larger than this between two consecutive readings is not something
+    # a bin fills up by; it is a fault or someone dumping a load.
+    ANOMALY_JUMP_PCT: float = 30.0
+
+    # Identical consecutive readings before the sensor is called stuck. A real
+    # bin's fill level moves a little every reading, so a value that has not
+    # changed at all this many times has frozen.
+    STUCK_READING_COUNT: int = 20
+
+    # Time allowed to collect a bin once it crosses each threshold, from the
+    # client's service level rules.
+    SLA_CRITICAL_MINUTES: float = 120.0
+    SLA_OVERFLOW_MINUTES: float = 30.0
+
+    @computed_field
+    @property
+    def DATABASE_URL(self) -> str:
+        """A psycopg2 connection URL.
+
+        Note this is the plain driver, not the async one the simulator uses:
+        writes happen inside Spark executors, which are threads, not an event
+        loop.
+        """
+        return (
+            f"postgresql://"
+            f"{self.POSTGRES_USER}:{self.POSTGRES_PASSWORD}"
+            f"@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}"
+            f"/{self.POSTGRES_DB}"
+        )
+
+    @computed_field
+    @property
+    def CONTRACT_PATH(self) -> Path:
+        """The shared telemetry contract.
+
+        Checked into the repository root and copied into the image, so both
+        services build their view of the payload from one file.
+        """
+        service_root = Path(__file__).resolve().parents[1]
+        candidates = (
+            service_root / "contracts" / "telemetry-v1.json",
+            service_root.parents[1] / "contracts" / "telemetry-v1.json",
+        )
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate
+        raise FileNotFoundError(
+            f"telemetry contract not found, looked in: "
+            f"{', '.join(str(c) for c in candidates)}"
+        )
+
+    def checkpoint_for(self, query_name: str) -> str:
+        """The checkpoint directory belonging to one named query."""
+        return f"{self.CHECKPOINT_ROOT}/{query_name}"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/services/stream-processor/src/config.py
+++ b/services/stream-processor/src/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     # without disturbing the others.
     CHECKPOINT_ROOT: str = "/data/checkpoints"
 
-    # The clean, deduplicated event history. Read by the nightly batch job, and
+    # The clean, deduplicated event history. Read by the batch rollup job, and
     # the only place a question nobody has asked yet can still be answered from.
     PARQUET_PATH: str = "/data/bin_events"
 
@@ -52,7 +52,14 @@ class Settings(BaseSettings):
     # window over which duplicates are detected.
     WATERMARK: str = "10 minutes"
 
-    STARTING_OFFSETS: str = "latest"
+    # Only consulted when a checkpoint does not exist yet, and on that first
+    # start "latest" loses data: the simulator is already publishing while
+    # Spark spends tens of seconds building four queries. That window is fatal
+    # for a bin that falls silent by design - it publishes its handful of
+    # readings, stops forever, and if they landed in the gap it never enters
+    # the state store at all, so no offline timeout is ever armed for it.
+    # MAX_OFFSETS_PER_TRIGGER keeps the resulting backlog from arriving at once.
+    STARTING_OFFSETS: str = "earliest"
 
     # Local mode: one machine, no master and no workers. A thousand events a
     # second does not need a cluster, and skipping it removes three containers
@@ -66,7 +73,7 @@ class Settings(BaseSettings):
     # inside the container where nothing can reach it.
     SPARK_UI_PORT: int = 4040
 
-    # The nightly batch job gets its own port. It runs alongside the streaming
+    # The batch rollup job gets its own port. It runs alongside the streaming
     # application, and without a separate port it silently lands on whatever
     # Spark finds free after retrying - so the address changes run to run and
     # the log carries a warning that reads like a fault.

--- a/services/stream-processor/src/logging_config.py
+++ b/services/stream-processor/src/logging_config.py
@@ -1,0 +1,71 @@
+"""Logging setup, matching the data-simulator's so both services read alike."""
+
+import logging
+import signal
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+import colorlog
+
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
+
+
+def setup_logging(level: str = "INFO") -> logging.Logger:
+    root = logging.getLogger()
+
+    # Prevent duplicate handlers
+    if root.handlers:
+        return root
+
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+
+    formatter = logging.Formatter(
+        "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+    )
+
+    color_formatter = colorlog.ColoredFormatter(
+        "%(log_color)s%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+        log_colors={
+            "DEBUG": "cyan",
+            "INFO": "green",
+            "WARNING": "yellow",
+            "ERROR": "red",
+            "CRITICAL": "bold_red",
+        },
+    )
+
+    console = colorlog.StreamHandler()
+    console.setFormatter(color_formatter)
+
+    file_handler = RotatingFileHandler(
+        LOG_DIR / "stream-processor.log",
+        maxBytes=20 * 1024 * 1024,  # 20 MB
+        backupCount=5,
+    )
+    file_handler.setFormatter(formatter)
+
+    root.addHandler(console)
+    root.addHandler(file_handler)
+
+    # py4j logs every gateway call at INFO, which buries everything else.
+    logging.getLogger("py4j").setLevel(logging.WARNING)
+
+    # For enabling debugs on a running process
+    signal.signal(signal.SIGUSR1, _toggle_log_level)
+
+    return root
+
+
+def _toggle_log_level(signum, frame):
+    root = logging.getLogger()
+
+    if root.level == logging.INFO:
+        root.setLevel(logging.DEBUG)
+    else:
+        root.setLevel(logging.INFO)
+
+    root.info(
+        "Runtime log level changed to %s",
+        logging.getLevelName(root.level),
+    )

--- a/services/stream-processor/src/main.py
+++ b/services/stream-processor/src/main.py
@@ -6,6 +6,8 @@ one of them can be reset without disturbing the rest.
 """
 
 import logging
+import signal
+import threading
 
 from config import get_settings
 from logging_config import setup_logging
@@ -18,12 +20,18 @@ setup_logging()
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
+# How long to block in the JVM before returning to Python to notice a signal.
+# Python runs a signal handler between bytecodes, so while the main thread sits
+# inside a py4j call nothing is noticed - which is why an unbounded wait here
+# meant SIGTERM was ignored until Docker gave up and sent SIGKILL.
+SHUTDOWN_POLL_SECONDS = 5
+
 
 def start_parquet_history(clean_events):
     """
     Write every clean reading to Parquet, partitioned by date.
 
-    This is the history the nightly job reads, and the only place a question
+    This is the history the batch job reads, and the only place a question
     nobody has asked yet can still be answered from.
     """
     return (
@@ -58,6 +66,31 @@ def start_dead_letters(raw):
     )
 
 
+def run(session, queries, stop_requested: threading.Event) -> None:
+    """
+    Block until a query ends or a stop is asked for, then shut down in order.
+
+    Stopping the queries rather than letting the process be killed lets each one
+    finish the micro-batch it is in and commit its offsets. Nothing is lost
+    either way - checkpoints exist for exactly that, and every write is
+    idempotent - but a killed container reports as a crash, which is a bad
+    signal to leave in `docker compose ps` for an ordinary stop.
+    """
+    while not stop_requested.is_set():
+        # Raises if a query failed, which is how a failure still surfaces.
+        if session.streams.awaitAnyTermination(timeout=SHUTDOWN_POLL_SECONDS):
+            logger.warning("A streaming query ended on its own")
+            break
+
+    for query in queries:
+        if query.isActive:
+            logger.info("Stopping query %s", query.name)
+            query.stop()
+
+    session.stop()
+    logger.info("Shutdown complete")
+
+
 def main() -> None:
     logger.info("Starting stream processor")
 
@@ -80,9 +113,16 @@ def main() -> None:
         ", ".join(query.name for query in queries),
     )
 
-    # Blocks until any query fails, which surfaces the failure instead of
-    # leaving the process alive with a dead query inside it.
-    session.streams.awaitAnyTermination()
+    stop_requested = threading.Event()
+
+    def handle_shutdown(*_):
+        logger.info("Shutdown signal received")
+        stop_requested.set()
+
+    for received in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(received, handle_shutdown)
+
+    run(session, queries, stop_requested)
 
 
 if __name__ == "__main__":

--- a/services/stream-processor/src/main.py
+++ b/services/stream-processor/src/main.py
@@ -9,7 +9,7 @@ import logging
 
 from config import get_settings
 from logging_config import setup_logging
-from pipeline import clean, zone_metrics
+from pipeline import bin_state, clean, zone_metrics
 from session import build_session, read_telemetry
 from sinks import apply_schema
 
@@ -71,6 +71,7 @@ def main() -> None:
         start_parquet_history(clean_events),
         start_dead_letters(raw),
         zone_metrics.start(clean_events),
+        bin_state.start(clean_events),
     ]
 
     logger.info(

--- a/services/stream-processor/src/main.py
+++ b/services/stream-processor/src/main.py
@@ -1,0 +1,88 @@
+"""Stream processor entrypoint.
+
+Reads the telemetry topic once and starts the streaming queries on it. Each
+query keeps its own checkpoint, so one failing does not stop the others and any
+one of them can be reset without disturbing the rest.
+"""
+
+import logging
+
+from config import get_settings
+from logging_config import setup_logging
+from pipeline import clean, zone_metrics
+from session import build_session, read_telemetry
+from sinks import apply_schema
+
+setup_logging()
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+def start_parquet_history(clean_events):
+    """
+    Write every clean reading to Parquet, partitioned by date.
+
+    This is the history the nightly job reads, and the only place a question
+    nobody has asked yet can still be answered from.
+    """
+    return (
+        clean.partitioned_by_date(clean_events)
+        .writeStream.format("parquet")
+        .outputMode("append")
+        .partitionBy("event_date")
+        .option("path", settings.PARQUET_PATH)
+        .option("checkpointLocation", settings.checkpoint_for("bin_events"))
+        .trigger(processingTime=settings.TRIGGER_INTERVAL)
+        .queryName("bin_events")
+        .start()
+    )
+
+
+def start_dead_letters(raw):
+    """
+    Forward messages that could not be believed to the dead-letter topic.
+
+    Kept as its own query rather than folded into the history write, so a
+    problem publishing dead letters cannot stop clean data being stored.
+    """
+    return (
+        clean.dead_letters(raw)
+        .writeStream.format("kafka")
+        .option("kafka.bootstrap.servers", settings.KAFKA_BOOTSTRAP_SERVERS)
+        .option("topic", settings.KAFKA_DLQ_TOPIC)
+        .option("checkpointLocation", settings.checkpoint_for("dead_letters"))
+        .trigger(processingTime=settings.TRIGGER_INTERVAL)
+        .queryName("dead_letters")
+        .start()
+    )
+
+
+def main() -> None:
+    logger.info("Starting stream processor")
+
+    apply_schema()
+
+    session = build_session()
+    raw = read_telemetry(session)
+    clean_events = clean.clean_events(raw)
+
+    queries = [
+        start_parquet_history(clean_events),
+        start_dead_letters(raw),
+        zone_metrics.start(clean_events),
+    ]
+
+    logger.info(
+        "Started %d streaming quer(ies): %s",
+        len(queries),
+        ", ".join(query.name for query in queries),
+    )
+
+    # Blocks until any query fails, which surfaces the failure instead of
+    # leaving the process alive with a dead query inside it.
+    session.streams.awaitAnyTermination()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/stream-processor/src/pipeline/bin_state.py
+++ b/services/stream-processor/src/pipeline/bin_state.py
@@ -71,6 +71,7 @@ OUTPUT_SCHEMA = StructType(
         StructField("longitude", DoubleType()),
         StructField("fill_rate_pct_per_min", DoubleType()),
         StructField("minutes_to_full", DoubleType()),
+        StructField("sensor_faults", StringType()),
         StructField("last_seen", TimestampType()),
     ]
 )
@@ -105,6 +106,9 @@ STATE_SCHEMA = StructType(
         StructField("predicted_fired", BooleanType()),
         StructField("sla_critical_fired", BooleanType()),
         StructField("sla_overflow_fired", BooleanType()),
+        # Whether a broken sensor has already been reported for this bin, so a
+        # permanently faulty one produces a single alert rather than a stream.
+        StructField("sensor_fault_fired", BooleanType()),
         # Fire risk is the exception: it repeats while it stays true, because a
         # fire does not stop being urgent because it was already reported.
         StructField("last_fire_risk_ms", LongType()),
@@ -132,6 +136,7 @@ EMPTY_STATE = {
     "predicted_fired": False,
     "sla_critical_fired": False,
     "sla_overflow_fired": False,
+    "sensor_fault_fired": False,
     "last_fire_risk_ms": 0,
 }
 
@@ -145,6 +150,7 @@ SEVERITY = {
     "SENSOR_STUCK": "MEDIUM",
     "ANOMALY_JUMP": "MEDIUM",
     "LOW_BATTERY": "MEDIUM",
+    "SENSOR_FAULT": "MEDIUM",
     "COLLECTED": "INFO",
 }
 
@@ -180,6 +186,7 @@ def _alert(memory: dict, bin_id: str, alert_type: str, event_ms: int, detail: st
         "longitude": memory["longitude"],
         "fill_rate_pct_per_min": None,
         "minutes_to_full": None,
+        "sensor_faults": None,
         "last_seen": _to_timestamp(memory["last_event_ms"]),
     }
 
@@ -378,6 +385,29 @@ def evaluate_reading(memory: dict, reading: dict, bin_id: str) -> list[dict]:
     elif battery is not None:
         memory["low_battery_fired"] = False
 
+    # ---- Broken sensors ----------------------------------------------------
+    # A reading arrives with individual sensors already nulled out by the
+    # cleaning step, which keeps the bin trackable when only one of them has
+    # failed. Without an alert here that repair would be silent, and a bin whose
+    # thermometer died would quietly stop contributing to fire risk with nobody
+    # told - which is the same blind spot as discarding it, only harder to see.
+    faults = reading.get("sensor_faults")
+
+    if faults:
+        if not memory["sensor_fault_fired"]:
+            alerts.append(
+                _alert(
+                    memory,
+                    bin_id,
+                    "SENSOR_FAULT",
+                    event_ms,
+                    f"unusable readings from: {faults}",
+                )
+            )
+            memory["sensor_fault_fired"] = True
+    else:
+        memory["sensor_fault_fired"] = False
+
     # ---- SLA clocks --------------------------------------------------------
     alerts.extend(_sla_breaches(memory, bin_id, event_ms))
 
@@ -452,7 +482,9 @@ def fill_projection(previous_pct, previous_ms, fill_pct, event_ms):
     return rate, (100 - fill_pct) / rate
 
 
-def state_record(memory: dict, bin_id: str, fill_rate, minutes_to_full) -> dict:
+def state_record(
+    memory: dict, bin_id: str, fill_rate, minutes_to_full, sensor_faults=None
+) -> dict:
     """The bin's current state, for the one-row-per-bin table."""
     return {
         "record_type": RECORD_STATE,
@@ -471,6 +503,7 @@ def state_record(memory: dict, bin_id: str, fill_rate, minutes_to_full) -> dict:
         "longitude": memory["longitude"],
         "fill_rate_pct_per_min": fill_rate,
         "minutes_to_full": minutes_to_full,
+        "sensor_faults": sensor_faults,
         "last_seen": _to_timestamp(memory["last_event_ms"]),
     }
 
@@ -514,7 +547,7 @@ def track_bin(key, pdfs, state):
         return
 
     alerts = []
-    fill_rate = minutes_to_full = None
+    fill_rate = minutes_to_full = sensor_faults = None
 
     for pdf in pdfs:
         # Events for one bin can arrive in any order within a batch, and every
@@ -533,10 +566,12 @@ def track_bin(key, pdfs, state):
                 "battery_level": _as_float(row["battery_level"]),
                 "latitude": _as_float(row["latitude"]),
                 "longitude": _as_float(row["longitude"]),
+                "sensor_faults": _as_text(row["sensor_faults"]),
                 "event_ms": int(row[EVENT_TIME_COLUMN].timestamp() * 1000),
             }
 
             alerts.extend(evaluate_reading(memory, reading, bin_id))
+            sensor_faults = reading["sensor_faults"]
             fill_rate, minutes_to_full = fill_projection(
                 previous_pct, previous_ms, reading["fill_pct"], reading["event_ms"]
             )
@@ -551,7 +586,9 @@ def track_bin(key, pdfs, state):
     )
     state.setTimeoutTimestamp(max(timeout_ms, state.getCurrentWatermarkMs() + 1))
 
-    rows = alerts + [state_record(memory, bin_id, fill_rate, minutes_to_full)]
+    rows = alerts + [
+        state_record(memory, bin_id, fill_rate, minutes_to_full, sensor_faults)
+    ]
     yield pd.DataFrame(rows, columns=OUTPUT_SCHEMA.fieldNames())
 
 
@@ -560,6 +597,13 @@ def _as_float(value):
     if value is None or pd.isna(value):
         return None
     return float(value)
+
+
+def _as_text(value):
+    """Pandas nulls become None so an absent fault is falsy, not the string 'nan'."""
+    if value is None or pd.isna(value):
+        return None
+    return str(value)
 
 
 # ---------------------------------------------------------------------------
@@ -590,6 +634,7 @@ STATE_COLUMNS = [
     "longitude",
     "fill_rate_pct_per_min",
     "minutes_to_full",
+    "sensor_faults",
     "last_seen",
 ]
 

--- a/services/stream-processor/src/pipeline/bin_state.py
+++ b/services/stream-processor/src/pipeline/bin_state.py
@@ -13,7 +13,7 @@ asked for a collection list, not a stream of the same fact. Firing once on entry
 and clearing on collection needs per-bin memory, which puts them here too.
 
 So there is one stateful operator keyed by bin, reading and writing state once
-per event, and emitting ten kinds of alert from it.
+per event, and emitting twelve kinds of alert from it.
 
 Dead-device detection is the one rule that is not a rule at all: it is the
 absence of events. Each event arms an event-time timeout, and when that fires
@@ -73,6 +73,10 @@ OUTPUT_SCHEMA = StructType(
         StructField("minutes_to_full", DoubleType()),
         StructField("sensor_faults", StringType()),
         StructField("last_seen", TimestampType()),
+        # Wall-clock time this row was produced, as opposed to last_seen, which
+        # is event time. The pair is what separates "this bin stopped
+        # reporting" from "the pipeline stopped writing".
+        StructField("updated_at", TimestampType()),
     ]
 )
 
@@ -106,9 +110,11 @@ STATE_SCHEMA = StructType(
         StructField("predicted_fired", BooleanType()),
         StructField("sla_critical_fired", BooleanType()),
         StructField("sla_overflow_fired", BooleanType()),
-        # Whether a broken sensor has already been reported for this bin, so a
-        # permanently faulty one produces a single alert rather than a stream.
-        StructField("sensor_fault_fired", BooleanType()),
+        # Which sensors were already reported broken, so a permanently faulty
+        # one produces a single alert rather than a stream - while a second
+        # sensor failing later is still news. A boolean here meant a bin whose
+        # thermometer was already dead could lose its battery reading silently.
+        StructField("reported_faults", StringType()),
         # Fire risk is the exception: it repeats while it stays true, because a
         # fire does not stop being urgent because it was already reported.
         StructField("last_fire_risk_ms", LongType()),
@@ -136,14 +142,18 @@ EMPTY_STATE = {
     "predicted_fired": False,
     "sla_critical_fired": False,
     "sla_overflow_fired": False,
-    "sensor_fault_fired": False,
+    "reported_faults": None,
     "last_fire_risk_ms": 0,
 }
 
 SEVERITY = {
     "OVERFLOW": "CRITICAL",
     "FIRE_RISK": "CRITICAL",
-    "SLA_BREACH": "CRITICAL",
+    # Two clocks, two alert types. One shared type collided in the database:
+    # both clocks can come due on the same reading, and the alert table keys on
+    # (bin_id, alert_type, fired_at), so one of the two was silently discarded.
+    "SLA_BREACH_OVERFLOW": "CRITICAL",
+    "SLA_BREACH_CRITICAL": "CRITICAL",
     "CRITICAL_FILL": "HIGH",
     "PREDICTED_OVERFLOW": "HIGH",
     "OFFLINE": "HIGH",
@@ -188,7 +198,15 @@ def _alert(memory: dict, bin_id: str, alert_type: str, event_ms: int, detail: st
         "minutes_to_full": None,
         "sensor_faults": None,
         "last_seen": _to_timestamp(memory["last_event_ms"]),
+        "updated_at": datetime.now(tz=timezone.utc),
     }
+
+
+def _faults(names) -> set[str]:
+    """The comma-separated fault names as a set, empty when there are none."""
+    if not names:
+        return set()
+    return {name for name in names.split(",") if name}
 
 
 def _to_timestamp(milliseconds) -> datetime | None:
@@ -267,7 +285,22 @@ def evaluate_reading(memory: dict, reading: dict, bin_id: str) -> list[dict]:
         )
 
     # ---- Stuck sensor ------------------------------------------------------
-    if previous_pct is not None and fill_pct == previous_pct:
+    # Not while saturated. A full bin reports exactly 100% every few seconds
+    # until a truck arrives, because the level is clamped at capacity and
+    # physically cannot read higher - so identical readings there say nothing
+    # about the sensor, and a full bin waiting for collection is the most
+    # ordinary state in the fleet.
+    #
+    # The cost is that a sensor genuinely frozen at 100% is never reported.
+    # That is not a gap worth closing: it is indistinguishable from a full bin.
+    #
+    # Zero is NOT the same case and is deliberately not excluded. Nothing
+    # clamps a bin at empty - waste accumulates - so a bin repeating 0% is a
+    # sensor that has stopped, which is exactly what the FROZEN fault produces
+    # and what this rule is for.
+    saturated = fill_pct >= 100
+
+    if previous_pct is not None and fill_pct == previous_pct and not saturated:
         memory["unchanged_count"] += 1
     else:
         memory["unchanged_count"] = 0
@@ -287,36 +320,30 @@ def evaluate_reading(memory: dict, reading: dict, bin_id: str) -> list[dict]:
         )
 
     # ---- Critical fill -----------------------------------------------------
-    if fill_pct >= settings.CRITICAL_FILL_PCT:
-        if not memory["critical_fired"]:
-            alerts.append(
-                _alert(
-                    memory,
-                    bin_id,
-                    "CRITICAL_FILL",
-                    event_ms,
-                    f"{fill_pct:.1f}% full",
-                )
+    # Cleared by a collection and by nothing else. Clearing on any reading back
+    # under the threshold looks equivalent and is not: a bin wobbling around
+    # 80% re-alerts on every crossing and restarts its SLA clock each time, so
+    # a bin nobody ever collects can stay permanently inside its SLA.
+    if fill_pct >= settings.CRITICAL_FILL_PCT and not memory["critical_fired"]:
+        alerts.append(
+            _alert(
+                memory,
+                bin_id,
+                "CRITICAL_FILL",
+                event_ms,
+                f"{fill_pct:.1f}% full",
             )
-            memory["critical_fired"] = True
-            memory["critical_since_ms"] = event_ms
-    else:
-        memory["critical_fired"] = False
-        memory["critical_since_ms"] = 0
+        )
+        memory["critical_fired"] = True
+        memory["critical_since_ms"] = event_ms
 
     # ---- Overflow ----------------------------------------------------------
-    if fill_pct >= settings.OVERFLOW_FILL_PCT:
-        if not memory["overflow_fired"]:
-            alerts.append(
-                _alert(
-                    memory, bin_id, "OVERFLOW", event_ms, f"{fill_pct:.1f}% full"
-                )
-            )
-            memory["overflow_fired"] = True
-            memory["overflow_since_ms"] = event_ms
-    else:
-        memory["overflow_fired"] = False
-        memory["overflow_since_ms"] = 0
+    if fill_pct >= settings.OVERFLOW_FILL_PCT and not memory["overflow_fired"]:
+        alerts.append(
+            _alert(memory, bin_id, "OVERFLOW", event_ms, f"{fill_pct:.1f}% full")
+        )
+        memory["overflow_fired"] = True
+        memory["overflow_since_ms"] = event_ms
 
     # ---- Predicted overflow ------------------------------------------------
     fill_rate, minutes_to_full = fill_projection(
@@ -391,22 +418,25 @@ def evaluate_reading(memory: dict, reading: dict, bin_id: str) -> list[dict]:
     # failed. Without an alert here that repair would be silent, and a bin whose
     # thermometer died would quietly stop contributing to fire risk with nobody
     # told - which is the same blind spot as discarding it, only harder to see.
+    # Compared as a set of names rather than as "any fault at all", so a second
+    # sensor failing while the first is still broken is reported. Recovery needs
+    # no branch of its own: the remembered set is replaced by what this reading
+    # says, so a name that stops appearing stops being outstanding.
     faults = reading.get("sensor_faults")
+    new_faults = _faults(faults) - _faults(memory["reported_faults"])
 
-    if faults:
-        if not memory["sensor_fault_fired"]:
-            alerts.append(
-                _alert(
-                    memory,
-                    bin_id,
-                    "SENSOR_FAULT",
-                    event_ms,
-                    f"unusable readings from: {faults}",
-                )
+    if new_faults:
+        alerts.append(
+            _alert(
+                memory,
+                bin_id,
+                "SENSOR_FAULT",
+                event_ms,
+                f"unusable readings from: {','.join(sorted(new_faults))}",
             )
-            memory["sensor_fault_fired"] = True
-    else:
-        memory["sensor_fault_fired"] = False
+        )
+
+    memory["reported_faults"] = faults or None
 
     # ---- SLA clocks --------------------------------------------------------
     alerts.extend(_sla_breaches(memory, bin_id, event_ms))
@@ -428,17 +458,19 @@ def _sla_breaches(memory: dict, bin_id: str, event_ms: int) -> list[dict]:
             "overflow_since_ms",
             "sla_overflow_fired",
             settings.SLA_OVERFLOW_MINUTES,
+            "SLA_BREACH_OVERFLOW",
             "overflowing",
         ),
         (
             "critical_since_ms",
             "sla_critical_fired",
             settings.SLA_CRITICAL_MINUTES,
+            "SLA_BREACH_CRITICAL",
             "critical",
         ),
     )
 
-    for since_key, fired_key, allowed_minutes, label in clocks:
+    for since_key, fired_key, allowed_minutes, alert_type, label in clocks:
         started = memory[since_key]
         if not started or memory[fired_key]:
             continue
@@ -449,7 +481,7 @@ def _sla_breaches(memory: dict, bin_id: str, event_ms: int) -> list[dict]:
                 _alert(
                     memory,
                     bin_id,
-                    "SLA_BREACH",
+                    alert_type,
                     event_ms,
                     f"{label} for {elapsed_minutes:.0f} minutes, "
                     f"allowed {allowed_minutes:.0f}",
@@ -505,6 +537,7 @@ def state_record(
         "minutes_to_full": minutes_to_full,
         "sensor_faults": sensor_faults,
         "last_seen": _to_timestamp(memory["last_event_ms"]),
+        "updated_at": datetime.now(tz=timezone.utc),
     }
 
 
@@ -636,6 +669,10 @@ STATE_COLUMNS = [
     "minutes_to_full",
     "sensor_faults",
     "last_seen",
+    # Written explicitly. Left to the column default it recorded when the bin
+    # was first seen and never moved again, since an upsert that does not name
+    # a column does not touch it.
+    "updated_at",
 ]
 
 

--- a/services/stream-processor/src/pipeline/bin_state.py
+++ b/services/stream-processor/src/pipeline/bin_state.py
@@ -1,0 +1,646 @@
+"""Query 2 - one function that remembers each bin.
+
+Eight of the client's fifteen problems ask the same underlying question: what did
+this bin say last time, and how long ago? Critical fill, overflow prediction,
+abnormal jumps, fire risk, dead devices, low battery, collection events, stuck
+sensors and the SLA clocks all answer it. Handled separately they would be eight
+queries each holding their own copy of the same per-bin memory.
+
+Three of them - critical fill, fire risk and low battery - look like plain
+filters. They are not. A bare filter re-fires for as long as the condition holds,
+so one bin stuck at 88% produces an alert every few seconds forever. The client
+asked for a collection list, not a stream of the same fact. Firing once on entry
+and clearing on collection needs per-bin memory, which puts them here too.
+
+So there is one stateful operator keyed by bin, reading and writing state once
+per event, and emitting ten kinds of alert from it.
+
+Dead-device detection is the one rule that is not a rule at all: it is the
+absence of events. Each event arms an event-time timeout, and when that fires
+Spark calls this function with no data and it reports the bin offline.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+import pandas as pd
+from pyspark.sql import DataFrame
+from pyspark.sql.streaming.state import GroupStateTimeout
+from pyspark.sql.types import (
+    BooleanType,
+    DoubleType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+from config import get_settings
+from schema import EVENT_TIME_COLUMN
+from sinks import write_batch
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+MINUTE_MS = 60_000
+
+# Rows leaving the operator are of two kinds, distinguished by record_type: the
+# alerts that fired, and the current state of the bin. They share one schema
+# because an operator emits one shape, and the batch writer routes each kind to
+# its own table.
+RECORD_ALERT = "ALERT"
+RECORD_STATE = "STATE"
+
+OUTPUT_SCHEMA = StructType(
+    [
+        StructField("record_type", StringType()),
+        StructField("bin_id", StringType()),
+        StructField("zone", StringType()),
+        StructField("alert_type", StringType()),
+        StructField("severity", StringType()),
+        StructField("fired_at", TimestampType()),
+        StructField("detail", StringType()),
+        StructField("capacity", DoubleType()),
+        StructField("current_fill_level", DoubleType()),
+        StructField("fill_pct", DoubleType()),
+        StructField("temperature", DoubleType()),
+        StructField("battery_level", DoubleType()),
+        StructField("latitude", DoubleType()),
+        StructField("longitude", DoubleType()),
+        StructField("fill_rate_pct_per_min", DoubleType()),
+        StructField("minutes_to_full", DoubleType()),
+        StructField("last_seen", TimestampType()),
+    ]
+)
+
+# What is remembered between events. Roughly two hundred bytes per bin, so about
+# a megabyte for a five thousand bin city - small enough that the size of this
+# is not the interesting constraint.
+STATE_SCHEMA = StructType(
+    [
+        StructField("zone", StringType()),
+        StructField("capacity", DoubleType()),
+        StructField("last_fill_level", DoubleType()),
+        StructField("last_fill_pct", DoubleType()),
+        StructField("last_temperature", DoubleType()),
+        StructField("last_battery", DoubleType()),
+        StructField("latitude", DoubleType()),
+        StructField("longitude", DoubleType()),
+        StructField("last_event_ms", LongType()),
+        # How many consecutive readings have been identical. A real bin's level
+        # moves a little every reading, so a value that has not changed at all
+        # for a long run has frozen.
+        StructField("unchanged_count", IntegerType()),
+        # When each SLA clock started, or 0 when it is not running. These are
+        # what a collection clears.
+        StructField("critical_since_ms", LongType()),
+        StructField("overflow_since_ms", LongType()),
+        # Which fire-once alerts are currently outstanding, so they are not
+        # repeated every few seconds for as long as the condition holds.
+        StructField("critical_fired", BooleanType()),
+        StructField("overflow_fired", BooleanType()),
+        StructField("low_battery_fired", BooleanType()),
+        StructField("predicted_fired", BooleanType()),
+        StructField("sla_critical_fired", BooleanType()),
+        StructField("sla_overflow_fired", BooleanType()),
+        # Fire risk is the exception: it repeats while it stays true, because a
+        # fire does not stop being urgent because it was already reported.
+        StructField("last_fire_risk_ms", LongType()),
+    ]
+)
+
+STATE_FIELDS = [field.name for field in STATE_SCHEMA.fields]
+
+EMPTY_STATE = {
+    "zone": None,
+    "capacity": None,
+    "last_fill_level": None,
+    "last_fill_pct": None,
+    "last_temperature": None,
+    "last_battery": None,
+    "latitude": None,
+    "longitude": None,
+    "last_event_ms": 0,
+    "unchanged_count": 0,
+    "critical_since_ms": 0,
+    "overflow_since_ms": 0,
+    "critical_fired": False,
+    "overflow_fired": False,
+    "low_battery_fired": False,
+    "predicted_fired": False,
+    "sla_critical_fired": False,
+    "sla_overflow_fired": False,
+    "last_fire_risk_ms": 0,
+}
+
+SEVERITY = {
+    "OVERFLOW": "CRITICAL",
+    "FIRE_RISK": "CRITICAL",
+    "SLA_BREACH": "CRITICAL",
+    "CRITICAL_FILL": "HIGH",
+    "PREDICTED_OVERFLOW": "HIGH",
+    "OFFLINE": "HIGH",
+    "SENSOR_STUCK": "MEDIUM",
+    "ANOMALY_JUMP": "MEDIUM",
+    "LOW_BATTERY": "MEDIUM",
+    "COLLECTED": "INFO",
+}
+
+
+def read_state(state) -> dict:
+    """The remembered values for this bin, or a blank slate for a new one."""
+    if not state.exists:
+        return dict(EMPTY_STATE)
+    return dict(zip(STATE_FIELDS, state.get))
+
+
+def write_state(state, values: dict) -> None:
+    """Store the remembered values, in the order the schema declares."""
+    state.update(tuple(values[name] for name in STATE_FIELDS))
+
+
+def _alert(memory: dict, bin_id: str, alert_type: str, event_ms: int, detail: str):
+    """Build one alert row from the bin's current state."""
+    return {
+        "record_type": RECORD_ALERT,
+        "bin_id": bin_id,
+        "zone": memory["zone"],
+        "alert_type": alert_type,
+        "severity": SEVERITY[alert_type],
+        "fired_at": _to_timestamp(event_ms),
+        "detail": detail,
+        "capacity": memory["capacity"],
+        "current_fill_level": memory["last_fill_level"],
+        "fill_pct": memory["last_fill_pct"],
+        "temperature": memory["last_temperature"],
+        "battery_level": memory["last_battery"],
+        "latitude": memory["latitude"],
+        "longitude": memory["longitude"],
+        "fill_rate_pct_per_min": None,
+        "minutes_to_full": None,
+        "last_seen": _to_timestamp(memory["last_event_ms"]),
+    }
+
+
+def _to_timestamp(milliseconds) -> datetime | None:
+    if not milliseconds:
+        return None
+    return datetime.fromtimestamp(milliseconds / 1000, tz=timezone.utc)
+
+
+def evaluate_reading(memory: dict, reading: dict, bin_id: str) -> list[dict]:
+    """
+    Fold one reading into the bin's memory and return the alerts it raised.
+
+    Separated from the Spark plumbing so the rules can be read, and tested,
+    without a cluster. `memory` is modified in place.
+    """
+    alerts = []
+
+    event_ms = reading["event_ms"]
+    fill_pct = reading["fill_pct"]
+    previous_pct = memory["last_fill_pct"]
+    previous_ms = memory["last_event_ms"]
+
+    # Everything below reads the current values from memory, so update first and
+    # let the rules describe the bin as it now is.
+    memory["zone"] = reading["zone"]
+    memory["capacity"] = reading["capacity"]
+    memory["last_fill_level"] = reading["current_fill_level"]
+    memory["last_fill_pct"] = fill_pct
+    memory["last_temperature"] = reading["temperature"]
+    memory["last_battery"] = reading["battery_level"]
+    memory["latitude"] = reading["latitude"]
+    memory["longitude"] = reading["longitude"]
+    memory["last_event_ms"] = event_ms
+
+    # ---- Collection --------------------------------------------------------
+    # A large drop, not any drop. Requiring the bin to have been substantially
+    # full first is what separates a truck emptying it from sensor noise, and it
+    # is the event that clears both SLA clocks.
+    collected = (
+        previous_pct is not None
+        and previous_pct >= settings.COLLECTION_DROP_FROM_PCT
+        and fill_pct < settings.COLLECTION_DROP_TO_PCT
+    )
+
+    if collected:
+        alerts.append(
+            _alert(
+                memory,
+                bin_id,
+                "COLLECTED",
+                event_ms,
+                f"emptied from {previous_pct:.1f}% to {fill_pct:.1f}%",
+            )
+        )
+        memory["critical_since_ms"] = 0
+        memory["overflow_since_ms"] = 0
+        memory["critical_fired"] = False
+        memory["overflow_fired"] = False
+        memory["predicted_fired"] = False
+        memory["sla_critical_fired"] = False
+        memory["sla_overflow_fired"] = False
+
+    # ---- Abnormal jump -----------------------------------------------------
+    elif (
+        previous_pct is not None
+        and fill_pct - previous_pct >= settings.ANOMALY_JUMP_PCT
+    ):
+        alerts.append(
+            _alert(
+                memory,
+                bin_id,
+                "ANOMALY_JUMP",
+                event_ms,
+                f"rose {fill_pct - previous_pct:.1f}% between readings",
+            )
+        )
+
+    # ---- Stuck sensor ------------------------------------------------------
+    if previous_pct is not None and fill_pct == previous_pct:
+        memory["unchanged_count"] += 1
+    else:
+        memory["unchanged_count"] = 0
+
+    # Fires on the reading that crosses the threshold, not every reading after
+    # it, so a permanently frozen sensor produces one alert rather than a stream.
+    if memory["unchanged_count"] == settings.STUCK_READING_COUNT:
+        alerts.append(
+            _alert(
+                memory,
+                bin_id,
+                "SENSOR_STUCK",
+                event_ms,
+                f"{memory['unchanged_count']} identical readings at "
+                f"{fill_pct:.1f}%",
+            )
+        )
+
+    # ---- Critical fill -----------------------------------------------------
+    if fill_pct >= settings.CRITICAL_FILL_PCT:
+        if not memory["critical_fired"]:
+            alerts.append(
+                _alert(
+                    memory,
+                    bin_id,
+                    "CRITICAL_FILL",
+                    event_ms,
+                    f"{fill_pct:.1f}% full",
+                )
+            )
+            memory["critical_fired"] = True
+            memory["critical_since_ms"] = event_ms
+    else:
+        memory["critical_fired"] = False
+        memory["critical_since_ms"] = 0
+
+    # ---- Overflow ----------------------------------------------------------
+    if fill_pct >= settings.OVERFLOW_FILL_PCT:
+        if not memory["overflow_fired"]:
+            alerts.append(
+                _alert(
+                    memory, bin_id, "OVERFLOW", event_ms, f"{fill_pct:.1f}% full"
+                )
+            )
+            memory["overflow_fired"] = True
+            memory["overflow_since_ms"] = event_ms
+    else:
+        memory["overflow_fired"] = False
+        memory["overflow_since_ms"] = 0
+
+    # ---- Predicted overflow ------------------------------------------------
+    fill_rate, minutes_to_full = fill_projection(
+        previous_pct, previous_ms, fill_pct, event_ms
+    )
+
+    if (
+        minutes_to_full is not None
+        and minutes_to_full <= 60
+        and fill_pct < settings.CRITICAL_FILL_PCT
+        and not memory["predicted_fired"]
+    ):
+        alerts.append(
+            _alert(
+                memory,
+                bin_id,
+                "PREDICTED_OVERFLOW",
+                event_ms,
+                f"full in about {minutes_to_full:.0f} minutes at "
+                f"{fill_rate:.2f}%/min",
+            )
+        )
+        memory["predicted_fired"] = True
+    elif minutes_to_full is None or minutes_to_full > 60:
+        memory["predicted_fired"] = False
+
+    # ---- Fire risk ---------------------------------------------------------
+    # Hot AND nearly full. Either alone is not an emergency: a hot empty bin is
+    # a warm day, and a full cool bin is just a full bin.
+    on_fire = (
+        reading["temperature"] is not None
+        and reading["temperature"] > settings.FIRE_RISK_TEMP_C
+        and fill_pct > settings.FIRE_RISK_FILL_PCT
+    )
+
+    if on_fire:
+        repeat_ms = settings.FIRE_RISK_REPEAT_MINUTES * MINUTE_MS
+        if event_ms - memory["last_fire_risk_ms"] >= repeat_ms:
+            alerts.append(
+                _alert(
+                    memory,
+                    bin_id,
+                    "FIRE_RISK",
+                    event_ms,
+                    f"{reading['temperature']:.1f} C at {fill_pct:.1f}% full",
+                )
+            )
+            memory["last_fire_risk_ms"] = event_ms
+    else:
+        memory["last_fire_risk_ms"] = 0
+
+    # ---- Low battery -------------------------------------------------------
+    battery = reading["battery_level"]
+    if battery is not None and battery < settings.LOW_BATTERY_PCT:
+        if not memory["low_battery_fired"]:
+            alerts.append(
+                _alert(
+                    memory,
+                    bin_id,
+                    "LOW_BATTERY",
+                    event_ms,
+                    f"battery at {battery:.1f}%",
+                )
+            )
+            memory["low_battery_fired"] = True
+    elif battery is not None:
+        memory["low_battery_fired"] = False
+
+    # ---- SLA clocks --------------------------------------------------------
+    alerts.extend(_sla_breaches(memory, bin_id, event_ms))
+
+    return alerts
+
+
+def _sla_breaches(memory: dict, bin_id: str, event_ms: int) -> list[dict]:
+    """
+    Alerts for bins left uncollected past the time the rules allow.
+
+    The clocks start when the bin crosses each threshold and are cleared by a
+    collection, so a breach means no truck came - not that the bin is full.
+    """
+    breaches = []
+
+    clocks = (
+        (
+            "overflow_since_ms",
+            "sla_overflow_fired",
+            settings.SLA_OVERFLOW_MINUTES,
+            "overflowing",
+        ),
+        (
+            "critical_since_ms",
+            "sla_critical_fired",
+            settings.SLA_CRITICAL_MINUTES,
+            "critical",
+        ),
+    )
+
+    for since_key, fired_key, allowed_minutes, label in clocks:
+        started = memory[since_key]
+        if not started or memory[fired_key]:
+            continue
+
+        elapsed_minutes = (event_ms - started) / MINUTE_MS
+        if elapsed_minutes > allowed_minutes:
+            breaches.append(
+                _alert(
+                    memory,
+                    bin_id,
+                    "SLA_BREACH",
+                    event_ms,
+                    f"{label} for {elapsed_minutes:.0f} minutes, "
+                    f"allowed {allowed_minutes:.0f}",
+                )
+            )
+            memory[fired_key] = True
+
+    return breaches
+
+
+def fill_projection(previous_pct, previous_ms, fill_pct, event_ms):
+    """
+    Rate of fill between two readings, and the minutes until full at that rate.
+
+    Returns (None, None) until the bin has reported twice, and whenever it is
+    not filling - a bin that just emptied has a negative rate, which projects to
+    a nonsensical time and must not be reported as one.
+    """
+    if previous_pct is None or not previous_ms or event_ms <= previous_ms:
+        return None, None
+
+    elapsed_minutes = (event_ms - previous_ms) / MINUTE_MS
+    if elapsed_minutes <= 0:
+        return None, None
+
+    rate = (fill_pct - previous_pct) / elapsed_minutes
+    if rate <= 0:
+        return rate, None
+
+    return rate, (100 - fill_pct) / rate
+
+
+def state_record(memory: dict, bin_id: str, fill_rate, minutes_to_full) -> dict:
+    """The bin's current state, for the one-row-per-bin table."""
+    return {
+        "record_type": RECORD_STATE,
+        "bin_id": bin_id,
+        "zone": memory["zone"],
+        "alert_type": None,
+        "severity": None,
+        "fired_at": None,
+        "detail": None,
+        "capacity": memory["capacity"],
+        "current_fill_level": memory["last_fill_level"],
+        "fill_pct": memory["last_fill_pct"],
+        "temperature": memory["last_temperature"],
+        "battery_level": memory["last_battery"],
+        "latitude": memory["latitude"],
+        "longitude": memory["longitude"],
+        "fill_rate_pct_per_min": fill_rate,
+        "minutes_to_full": minutes_to_full,
+        "last_seen": _to_timestamp(memory["last_event_ms"]),
+    }
+
+
+def track_bin(key, pdfs, state):
+    """
+    Handle every event that arrived for one bin in this batch, plus timeouts.
+
+    Args:
+        key:
+            The grouping key, a one-element tuple of bin_id.
+
+        pdfs:
+            An iterator of pandas frames holding this bin's events. Empty when
+            Spark is calling because the bin's timeout expired.
+
+        state:
+            The bin's remembered values, carried across batches.
+
+    Yields:
+        Alert rows and one current-state row, as pandas frames.
+    """
+    bin_id = key[0]
+    memory = read_state(state)
+
+    # The bin went quiet. This is dead-device detection: the absence of events,
+    # noticed by a timer rather than by a rule, reporting when it was last seen.
+    if state.hasTimedOut:
+        silent_minutes = settings.OFFLINE_AFTER_MINUTES
+        offline = _alert(
+            memory,
+            bin_id,
+            "OFFLINE",
+            memory["last_event_ms"] + int(silent_minutes * MINUTE_MS),
+            f"no telemetry for {silent_minutes:.0f} minutes",
+        )
+        # State is kept, not removed, so the bin can be recognised as the same
+        # bin if it starts reporting again.
+        state.update(tuple(memory[name] for name in STATE_FIELDS))
+        yield pd.DataFrame([offline])
+        return
+
+    alerts = []
+    fill_rate = minutes_to_full = None
+
+    for pdf in pdfs:
+        # Events for one bin can arrive in any order within a batch, and every
+        # rule here compares against the previous reading. Out of order, a rise
+        # reads as a drop and a collection is invented that never happened.
+        for _, row in pdf.sort_values(EVENT_TIME_COLUMN).iterrows():
+            previous_pct = memory["last_fill_pct"]
+            previous_ms = memory["last_event_ms"]
+
+            reading = {
+                "zone": row["zone"],
+                "capacity": _as_float(row["capacity"]),
+                "current_fill_level": _as_float(row["current_fill_level"]),
+                "fill_pct": _as_float(row["fill_pct"]),
+                "temperature": _as_float(row["temperature"]),
+                "battery_level": _as_float(row["battery_level"]),
+                "latitude": _as_float(row["latitude"]),
+                "longitude": _as_float(row["longitude"]),
+                "event_ms": int(row[EVENT_TIME_COLUMN].timestamp() * 1000),
+            }
+
+            alerts.extend(evaluate_reading(memory, reading, bin_id))
+            fill_rate, minutes_to_full = fill_projection(
+                previous_pct, previous_ms, reading["fill_pct"], reading["event_ms"]
+            )
+
+    write_state(state, memory)
+
+    # Arm the timeout that becomes the offline alert. Clamped above the current
+    # watermark because Spark rejects a timeout already in the past, which is
+    # what a late-arriving event would otherwise ask for.
+    timeout_ms = memory["last_event_ms"] + int(
+        settings.OFFLINE_AFTER_MINUTES * MINUTE_MS
+    )
+    state.setTimeoutTimestamp(max(timeout_ms, state.getCurrentWatermarkMs() + 1))
+
+    rows = alerts + [state_record(memory, bin_id, fill_rate, minutes_to_full)]
+    yield pd.DataFrame(rows, columns=OUTPUT_SCHEMA.fieldNames())
+
+
+def _as_float(value):
+    """Pandas nulls become None so they reach PostgreSQL as NULL, not NaN."""
+    if value is None or pd.isna(value):
+        return None
+    return float(value)
+
+
+# ---------------------------------------------------------------------------
+# Spark wiring
+# ---------------------------------------------------------------------------
+
+ALERT_COLUMNS = [
+    "bin_id",
+    "zone",
+    "alert_type",
+    "severity",
+    "fired_at",
+    "fill_pct",
+    "temperature",
+    "battery_level",
+    "detail",
+]
+
+STATE_COLUMNS = [
+    "bin_id",
+    "zone",
+    "capacity",
+    "current_fill_level",
+    "fill_pct",
+    "temperature",
+    "battery_level",
+    "latitude",
+    "longitude",
+    "fill_rate_pct_per_min",
+    "minutes_to_full",
+    "last_seen",
+]
+
+
+def evaluate(clean_events: DataFrame) -> DataFrame:
+    """Run the stateful operator over the clean stream."""
+    return clean_events.groupBy("bin_id").applyInPandasWithState(
+        track_bin,
+        outputStructType=OUTPUT_SCHEMA,
+        stateStructType=STATE_SCHEMA,
+        outputMode="append",
+        timeoutConf=GroupStateTimeout.EventTimeTimeout,
+    )
+
+
+def _write(batch: DataFrame, batch_id: int) -> None:
+    """
+    Write one micro-batch: alerts appended, bin state replaced.
+
+    The batch is cached because it is read twice, once for each destination, and
+    without it the whole stateful computation would be re-run for the second
+    read.
+    """
+    batch.persist()
+    try:
+        alerts = batch.filter(batch.record_type == RECORD_ALERT)
+        # Alerts are facts about an instant and are never revised, so a retry of
+        # this batch produces identical rows that are discarded rather than
+        # duplicated.
+        write_batch(
+            alerts,
+            "bin_alerts",
+            ALERT_COLUMNS,
+            ["bin_id", "alert_type", "fired_at"],
+            mode="ignore",
+        )
+
+        states = batch.filter(batch.record_type == RECORD_STATE)
+        write_batch(states, "bin_state_latest", STATE_COLUMNS, ["bin_id"], "upsert")
+    finally:
+        batch.unpersist()
+
+
+def start(clean_events: DataFrame):
+    """Start the per-bin alerting query."""
+    return (
+        evaluate(clean_events)
+        .writeStream.outputMode("append")
+        .foreachBatch(_write)
+        .option("checkpointLocation", settings.checkpoint_for("bin_state"))
+        .trigger(processingTime=settings.TRIGGER_INTERVAL)
+        .queryName("bin_state")
+        .start()
+    )

--- a/services/stream-processor/src/pipeline/clean.py
+++ b/services/stream-processor/src/pipeline/clean.py
@@ -32,7 +32,6 @@ from schema import (
     EVENT_TIME_COLUMN,
     EVENT_TIME_FIELD,
     range_rules,
-    required_fields,
     telemetry_schema,
 )
 
@@ -50,8 +49,31 @@ CLEAN_COLUMNS = [
     "temperature",
     "latitude",
     "longitude",
+    "sensor_faults",
     EVENT_TIME_COLUMN,
 ]
+
+# Fields the pipeline can do nothing useful without. A message that cannot say
+# which bin it came from, when it was taken, or how full the bin is has nothing
+# left to salvage, so it is dead-lettered whole.
+TRACKING_FIELDS = (
+    "bin_id",
+    "zone",
+    "capacity",
+    "current_fill_level",
+    EVENT_TIME_FIELD,
+)
+
+# Readings that can be wrong on their own without making the rest of the message
+# a lie. A failed thermometer says nothing about how full the bin is.
+#
+# Rejecting the whole message for one of these was a monitoring blind spot: the
+# bin never reached the state store, so it vanished from every dashboard figure
+# AND never armed an offline timeout - a bin publishing every few seconds became
+# completely invisible, and the loudest possible sensor failure produced the
+# quietest possible outcome. These fields are nulled and the reading kept, so
+# the bin stays tracked and the fault is reported as an alert of its own.
+REPAIRABLE_FIELDS = ("temperature", "battery_level", "latitude", "longitude")
 
 
 def parse(raw: DataFrame) -> DataFrame:
@@ -78,9 +100,32 @@ def parse(raw: DataFrame) -> DataFrame:
     )
 
 
+def _out_of_range(field: str, minimum, maximum):
+    """A condition matching values the contract says are impossible."""
+    condition = None
+
+    if minimum is not None:
+        condition = col(field) < lit(minimum)
+    if maximum is not None:
+        above = col(field) > lit(maximum)
+        condition = above if condition is None else condition | above
+
+    return condition
+
+
+def _bounds() -> dict:
+    """The contract's numeric bounds, keyed by field."""
+    return {field: (low, high) for field, low, high in range_rules()}
+
+
 def rejection_reason(parsed: DataFrame):
     """
-    Build the column naming why a reading is not believable, or null if it is.
+    Build the column naming why a message is unusable, or null if it is usable.
+
+    Only failures in the fields the pipeline actually needs count here. A bad
+    thermometer is handled by :func:`sensor_fault_reason` instead, so a bin with
+    one broken sensor stays visible rather than disappearing from monitoring
+    entirely.
 
     The range checks come from the shared contract rather than being restated
     here, so the bounds a reading is judged against are the published ones. This
@@ -89,39 +134,35 @@ def rejection_reason(parsed: DataFrame):
     is looking for, and would be discarded as impossible by an ambient-only
     range.
 
-    A reading gets every reason that applies rather than just the first, since
-    knowing a message failed three checks is more useful than knowing it failed
-    one.
+    A message gets every reason that applies rather than just the first, since
+    knowing it failed three checks is more useful than knowing it failed one.
     """
     reasons = []
+    bounds = _bounds()
 
     # A message that did not parse at all arrives as a row of nulls.
     reasons.append(
         when(col("bin_id").isNull(), lit("unparseable_or_missing_bin_id"))
     )
 
-    for field in required_fields():
+    for field in TRACKING_FIELDS:
         if field == "bin_id":
             continue
         reasons.append(when(col(field).isNull(), lit(f"missing_{field}")))
+
+        minimum, maximum = bounds.get(field, (None, None))
+        condition = _out_of_range(field, minimum, maximum)
+        if condition is not None:
+            reasons.append(when(condition, lit(f"{field}_out_of_range")))
 
     reasons.append(
         when(col(EVENT_TIME_COLUMN).isNull(), lit("unparseable_timestamp"))
     )
 
-    for field, minimum, maximum in range_rules():
-        if minimum is not None:
-            reasons.append(
-                when(col(field) < lit(minimum), lit(f"{field}_below_{minimum}"))
-            )
-        if maximum is not None:
-            reasons.append(
-                when(col(field) > lit(maximum), lit(f"{field}_above_{maximum}"))
-            )
-
     # A bin cannot hold more than it holds. This is a relationship between two
     # fields rather than a bound on one, so it has no place in the contract's
-    # per-field ranges and is checked here.
+    # per-field ranges and is checked here. It is fatal rather than repairable
+    # because the fill level is the one reading everything downstream is about.
     reasons.append(
         when(
             col("current_fill_level") > col("capacity"),
@@ -130,23 +171,75 @@ def rejection_reason(parsed: DataFrame):
     )
 
     # concat_ws drops nulls, so unmatched checks contribute nothing and a
-    # believable reading produces an empty string, normalised to null below.
+    # believable message produces an empty string, normalised to null below.
     joined = concat_ws(",", *reasons)
     return when(joined == "", lit(None).cast("string")).otherwise(joined)
 
 
+def sensor_fault_reason(parsed: DataFrame):
+    """
+    Name the individual sensors reporting nonsense, or null if none are.
+
+    Computed before those fields are nulled, since afterwards there is nothing
+    left to tell the difference between a broken sensor and an absent one.
+    """
+    bounds = _bounds()
+    faults = []
+
+    for field in REPAIRABLE_FIELDS:
+        minimum, maximum = bounds.get(field, (None, None))
+        condition = _out_of_range(field, minimum, maximum)
+
+        if condition is not None:
+            faults.append(when(condition, lit(field)))
+
+        faults.append(when(col(field).isNull(), lit(f"{field}_missing")))
+
+    joined = concat_ws(",", *faults)
+    return when(joined == "", lit(None).cast("string")).otherwise(joined)
+
+
+def repair(flagged: DataFrame) -> DataFrame:
+    """
+    Null the individual readings that cannot be true, keeping the rest.
+
+    Nulled rather than clamped on purpose. Clamping 150 C to 120 C would invent
+    a plausible-looking number that no sensor reported, and it would be averaged
+    into the zone temperature as though it were real. A null is honest about the
+    fact that the reading is missing.
+    """
+    bounds = _bounds()
+    repaired = flagged
+
+    for field in REPAIRABLE_FIELDS:
+        minimum, maximum = bounds.get(field, (None, None))
+        condition = _out_of_range(field, minimum, maximum)
+
+        if condition is None:
+            continue
+
+        repaired = repaired.withColumn(
+            field,
+            when(condition, lit(None).cast("double")).otherwise(col(field)),
+        )
+
+    return repaired
+
+
 def split_valid_and_rejected(parsed: DataFrame) -> tuple[DataFrame, DataFrame]:
     """
-    Separate believable readings from the rest.
+    Separate usable readings from unusable messages, repairing the salvageable.
 
     Rejected messages are not dropped. A dropped message is indistinguishable
     from one that was never sent, which matters here more than usual: dead
     device detection works by noticing an absence, so silently discarding a
     bin's messages would make a healthy bin look dead.
     """
-    flagged = parsed.withColumn("reject_reason", rejection_reason(parsed))
+    flagged = parsed.withColumn(
+        "reject_reason", rejection_reason(parsed)
+    ).withColumn("sensor_faults", sensor_fault_reason(parsed))
 
-    valid = flagged.filter(col("reject_reason").isNull())
+    valid = repair(flagged.filter(col("reject_reason").isNull()))
     rejected = flagged.filter(col("reject_reason").isNotNull())
 
     return valid, rejected

--- a/services/stream-processor/src/pipeline/clean.py
+++ b/services/stream-processor/src/pipeline/clean.py
@@ -1,0 +1,217 @@
+"""Query 1 - parse, validate, deduplicate.
+
+This is the shared front of the pipeline: every other query reads its output, so
+a reading is parsed, checked and deduplicated exactly once no matter how many
+consumers it has. It is a plain DataFrame transformation rather than a hop
+through storage, so nothing is written and read back between queries.
+
+Two of the client's problems are answered here outright. Duplicate events are
+removed, and readings no sensor could have produced are separated out - the
+other half of that problem, a fill level that jumps impossibly between two
+readings, needs the previous reading and belongs to the stateful query.
+"""
+
+import logging
+
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import (
+    coalesce,
+    col,
+    concat_ws,
+    from_json,
+    lit,
+    struct,
+    to_date,
+    to_json,
+    to_timestamp,
+    when,
+)
+
+from config import get_settings
+from schema import (
+    EVENT_TIME_COLUMN,
+    EVENT_TIME_FIELD,
+    range_rules,
+    required_fields,
+    telemetry_schema,
+)
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+# Columns carried through to every downstream query.
+CLEAN_COLUMNS = [
+    "bin_id",
+    "zone",
+    "capacity",
+    "current_fill_level",
+    "fill_pct",
+    "battery_level",
+    "temperature",
+    "latitude",
+    "longitude",
+    EVENT_TIME_COLUMN,
+]
+
+
+def parse(raw: DataFrame) -> DataFrame:
+    """
+    Turn Kafka records into typed telemetry columns.
+
+    The raw value is kept alongside the parsed columns so a message that fails
+    validation can be dead-lettered exactly as it arrived, rather than as a
+    partial reconstruction of itself.
+    """
+    return (
+        raw.select(
+            col("value").cast("string").alias("raw_value"),
+            col("topic"),
+            col("partition"),
+            col("offset"),
+            from_json(col("value").cast("string"), telemetry_schema()).alias("data"),
+        )
+        .select("raw_value", "topic", "partition", "offset", "data.*")
+        .withColumn(
+            EVENT_TIME_COLUMN,
+            to_timestamp(col(EVENT_TIME_FIELD)),
+        )
+    )
+
+
+def rejection_reason(parsed: DataFrame):
+    """
+    Build the column naming why a reading is not believable, or null if it is.
+
+    The range checks come from the shared contract rather than being restated
+    here, so the bounds a reading is judged against are the published ones. This
+    matters in both directions: too narrow a range rejects the very readings a
+    rule exists to catch - a bin above 70 C is exactly what fire risk detection
+    is looking for, and would be discarded as impossible by an ambient-only
+    range.
+
+    A reading gets every reason that applies rather than just the first, since
+    knowing a message failed three checks is more useful than knowing it failed
+    one.
+    """
+    reasons = []
+
+    # A message that did not parse at all arrives as a row of nulls.
+    reasons.append(
+        when(col("bin_id").isNull(), lit("unparseable_or_missing_bin_id"))
+    )
+
+    for field in required_fields():
+        if field == "bin_id":
+            continue
+        reasons.append(when(col(field).isNull(), lit(f"missing_{field}")))
+
+    reasons.append(
+        when(col(EVENT_TIME_COLUMN).isNull(), lit("unparseable_timestamp"))
+    )
+
+    for field, minimum, maximum in range_rules():
+        if minimum is not None:
+            reasons.append(
+                when(col(field) < lit(minimum), lit(f"{field}_below_{minimum}"))
+            )
+        if maximum is not None:
+            reasons.append(
+                when(col(field) > lit(maximum), lit(f"{field}_above_{maximum}"))
+            )
+
+    # A bin cannot hold more than it holds. This is a relationship between two
+    # fields rather than a bound on one, so it has no place in the contract's
+    # per-field ranges and is checked here.
+    reasons.append(
+        when(
+            col("current_fill_level") > col("capacity"),
+            lit("fill_level_exceeds_capacity"),
+        )
+    )
+
+    # concat_ws drops nulls, so unmatched checks contribute nothing and a
+    # believable reading produces an empty string, normalised to null below.
+    joined = concat_ws(",", *reasons)
+    return when(joined == "", lit(None).cast("string")).otherwise(joined)
+
+
+def split_valid_and_rejected(parsed: DataFrame) -> tuple[DataFrame, DataFrame]:
+    """
+    Separate believable readings from the rest.
+
+    Rejected messages are not dropped. A dropped message is indistinguishable
+    from one that was never sent, which matters here more than usual: dead
+    device detection works by noticing an absence, so silently discarding a
+    bin's messages would make a healthy bin look dead.
+    """
+    flagged = parsed.withColumn("reject_reason", rejection_reason(parsed))
+
+    valid = flagged.filter(col("reject_reason").isNull())
+    rejected = flagged.filter(col("reject_reason").isNotNull())
+
+    return valid, rejected
+
+
+def clean_events(raw: DataFrame) -> DataFrame:
+    """
+    The clean stream every downstream query reads.
+
+    Deduplication runs before anything else, so no duplicate ever reaches the
+    stateful operator or the aggregates. It keys on (bin_id, event time) within
+    the watermark, which is why a re-sent duplicate has to carry its original
+    timestamp - a fresh one makes it a distinct event that passes straight
+    through.
+
+    Note there is no join here. Zone and capacity travel on every event, so the
+    stream needs no lookup against the bins table at all. That removes a
+    database dependency from the hot path, and with it the problem of a bin
+    registered after the job started being enriched with nulls.
+    """
+    valid, _ = split_valid_and_rejected(parse(raw))
+
+    return (
+        valid.withWatermark(EVENT_TIME_COLUMN, settings.WATERMARK)
+        .dropDuplicatesWithinWatermark(["bin_id", EVENT_TIME_COLUMN])
+        .withColumn(
+            "fill_pct",
+            # Guarded rather than assumed: capacity is validated as positive
+            # upstream, but a division that can produce infinity would poison
+            # every average downstream, and one bad row is not worth that.
+            when(
+                col("capacity") > 0,
+                col("current_fill_level") / col("capacity") * 100,
+            ).otherwise(lit(None).cast("double")),
+        )
+        .select(*CLEAN_COLUMNS)
+    )
+
+
+def dead_letters(raw: DataFrame) -> DataFrame:
+    """
+    The rejected messages, shaped for the dead-letter topic.
+
+    Keyed by bin_id where one could be read, so a bin's bad messages land on one
+    partition alongside a record of where they came from.
+    """
+    _, rejected = split_valid_and_rejected(parse(raw))
+
+    return rejected.select(
+        coalesce(col("bin_id"), lit("unknown")).cast("string").alias("key"),
+        # Built with Spark's own JSON writer so the original payload is embedded
+        # as a properly escaped string. An unparseable message is exactly the
+        # kind that contains whatever would break a hand-assembled envelope.
+        to_json(
+            struct(
+                col("reject_reason").alias("reason"),
+                col("topic").alias("source_topic"),
+                col("partition").alias("source_partition"),
+                col("offset").alias("source_offset"),
+                col("raw_value").alias("payload"),
+            )
+        ).alias("value"),
+    )
+
+
+def partitioned_by_date(clean: DataFrame) -> DataFrame:
+    """Add the date column the Parquet history is partitioned by."""
+    return clean.withColumn("event_date", to_date(col(EVENT_TIME_COLUMN)))

--- a/services/stream-processor/src/pipeline/clean.py
+++ b/services/stream-processor/src/pipeline/clean.py
@@ -24,6 +24,7 @@ from pyspark.sql.functions import (
     to_date,
     to_json,
     to_timestamp,
+    trim,
     when,
 )
 
@@ -31,6 +32,7 @@ from config import get_settings
 from schema import (
     EVENT_TIME_COLUMN,
     EVENT_TIME_FIELD,
+    non_empty_fields,
     range_rules,
     telemetry_schema,
 )
@@ -100,12 +102,22 @@ def parse(raw: DataFrame) -> DataFrame:
     )
 
 
-def _out_of_range(field: str, minimum, maximum):
-    """A condition matching values the contract says are impossible."""
+def _out_of_range(field: str, minimum, maximum, minimum_exclusive=False):
+    """
+    A condition matching values the contract says are impossible.
+
+    `minimum_exclusive` is the difference between "at least zero" and "more
+    than zero", which for capacity is the difference between a usable reading
+    and a division that produces nothing.
+    """
     condition = None
 
     if minimum is not None:
-        condition = col(field) < lit(minimum)
+        condition = (
+            col(field) <= lit(minimum)
+            if minimum_exclusive
+            else col(field) < lit(minimum)
+        )
     if maximum is not None:
         above = col(field) > lit(maximum)
         condition = above if condition is None else condition | above
@@ -115,7 +127,9 @@ def _out_of_range(field: str, minimum, maximum):
 
 def _bounds() -> dict:
     """The contract's numeric bounds, keyed by field."""
-    return {field: (low, high) for field, low, high in range_rules()}
+    return {
+        field: (low, high, exclusive) for field, low, high, exclusive in range_rules()
+    }
 
 
 def rejection_reason(parsed: DataFrame):
@@ -150,10 +164,18 @@ def rejection_reason(parsed: DataFrame):
             continue
         reasons.append(when(col(field).isNull(), lit(f"missing_{field}")))
 
-        minimum, maximum = bounds.get(field, (None, None))
-        condition = _out_of_range(field, minimum, maximum)
+        minimum, maximum, exclusive = bounds.get(field, (None, None, False))
+        condition = _out_of_range(field, minimum, maximum, exclusive)
         if condition is not None:
             reasons.append(when(condition, lit(f"{field}_out_of_range")))
+
+    # An identifier made of nothing is not a missing identifier - it survives
+    # every null check and then groups unrelated events under one empty state
+    # key. The contract already says these carry at least one character.
+    for field in non_empty_fields():
+        if field not in TRACKING_FIELDS:
+            continue
+        reasons.append(when(trim(col(field)) == lit(""), lit(f"empty_{field}")))
 
     reasons.append(
         when(col(EVENT_TIME_COLUMN).isNull(), lit("unparseable_timestamp"))
@@ -187,8 +209,8 @@ def sensor_fault_reason(parsed: DataFrame):
     faults = []
 
     for field in REPAIRABLE_FIELDS:
-        minimum, maximum = bounds.get(field, (None, None))
-        condition = _out_of_range(field, minimum, maximum)
+        minimum, maximum, exclusive = bounds.get(field, (None, None, False))
+        condition = _out_of_range(field, minimum, maximum, exclusive)
 
         if condition is not None:
             faults.append(when(condition, lit(field)))
@@ -212,8 +234,8 @@ def repair(flagged: DataFrame) -> DataFrame:
     repaired = flagged
 
     for field in REPAIRABLE_FIELDS:
-        minimum, maximum = bounds.get(field, (None, None))
-        condition = _out_of_range(field, minimum, maximum)
+        minimum, maximum, exclusive = bounds.get(field, (None, None, False))
+        condition = _out_of_range(field, minimum, maximum, exclusive)
 
         if condition is None:
             continue

--- a/services/stream-processor/src/pipeline/zone_metrics.py
+++ b/services/stream-processor/src/pipeline/zone_metrics.py
@@ -1,0 +1,124 @@
+"""Query 3 - five-minute aggregates per zone.
+
+Five of the client's questions are the same numbers at different grains: daily
+collection efficiency, which zone generates the most waste, peak hours, the
+dashboard headline figures and long-range trends. Rather than a query each, this
+writes one five-minute aggregate per zone and lets SQL roll it up to hourly,
+daily, weekly or monthly.
+
+That keeps a month of history out of streaming state, which streaming holds
+badly, and it means the dashboard costs no Spark code at all - it is a view.
+
+Twelve windows an hour across a handful of zones is a couple of thousand rows a
+day, which PostgreSQL does not notice.
+"""
+
+import logging
+
+from pyspark.sql import DataFrame
+from pyspark.sql.functions import (
+    approx_count_distinct,
+    avg,
+    col,
+    count,
+    max as spark_max,
+    sum as spark_sum,
+    when,
+    window,
+)
+
+from config import get_settings
+from schema import EVENT_TIME_COLUMN
+from sinks import write_batch
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+WINDOW_DURATION = "5 minutes"
+
+TABLE = "zone_metrics_5m"
+KEY = ["window_start", "zone"]
+COLUMNS = [
+    "window_start",
+    "window_end",
+    "zone",
+    "bins_reporting",
+    "reading_count",
+    "avg_fill_pct",
+    "max_fill_pct",
+    "avg_temperature",
+    "max_temperature",
+    "critical_readings",
+    "overflow_readings",
+]
+
+
+def aggregate(clean_events: DataFrame) -> DataFrame:
+    """
+    Roll clean readings up into one row per zone per five-minute window.
+
+    The counts of readings crossing each threshold are carried alongside the
+    averages because an average hides the thing operations care about: a zone
+    averaging 45% while a handful of its bins sit above 95% is not a calm zone.
+    """
+    return (
+        clean_events.groupBy(
+            window(col(EVENT_TIME_COLUMN), WINDOW_DURATION),
+            col("zone"),
+        )
+        .agg(
+            # Approximate because exact distinct counting holds every key seen
+            # in the window, and the number only ever feeds a dashboard tile.
+            approx_count_distinct("bin_id").alias("bins_reporting"),
+            count("*").alias("reading_count"),
+            avg("fill_pct").alias("avg_fill_pct"),
+            spark_max("fill_pct").alias("max_fill_pct"),
+            avg("temperature").alias("avg_temperature"),
+            spark_max("temperature").alias("max_temperature"),
+            spark_sum(
+                when(col("fill_pct") >= settings.CRITICAL_FILL_PCT, 1).otherwise(0)
+            ).alias("critical_readings"),
+            spark_sum(
+                when(col("fill_pct") >= settings.OVERFLOW_FILL_PCT, 1).otherwise(0)
+            ).alias("overflow_readings"),
+        )
+        .select(
+            col("window.start").alias("window_start"),
+            col("window.end").alias("window_end"),
+            col("zone"),
+            *[
+                col(name)
+                for name in COLUMNS
+                if name not in ("window_start", "window_end", "zone")
+            ],
+        )
+    )
+
+
+def _write(batch: DataFrame, batch_id: int) -> None:
+    """Write one micro-batch of completed windows.
+
+    Upserted rather than appended. Append mode emits each window once, but a
+    failed write is retried with the same batch, and an append would then count
+    that window twice.
+    """
+    write_batch(batch, TABLE, COLUMNS, KEY, mode="upsert")
+
+
+def start(clean_events: DataFrame):
+    """
+    Start the zone aggregate query.
+
+    Append output mode, so a window is written only once the watermark has moved
+    past it and it can no longer change. That makes each row final on arrival,
+    which is what lets the API read this table without worrying about revisions.
+    """
+    return (
+        aggregate(clean_events)
+        .writeStream.outputMode("append")
+        .foreachBatch(_write)
+        .option("checkpointLocation", settings.checkpoint_for("zone_metrics"))
+        .trigger(processingTime=settings.TRIGGER_INTERVAL)
+        .queryName("zone_metrics")
+        .start()
+    )

--- a/services/stream-processor/src/schema.py
+++ b/services/stream-processor/src/schema.py
@@ -56,12 +56,19 @@ def telemetry_schema() -> StructType:
 
 
 @lru_cache
-def range_rules() -> tuple[tuple[str, float | None, float | None], ...]:
-    """The numeric bounds the contract declares, as (field, minimum, maximum).
+def range_rules() -> tuple[tuple[str, float | None, float | None, bool], ...]:
+    """
+    The numeric bounds the contract declares.
 
-    Used to build the validation step, so the ranges a reading is checked
-    against are the published ones rather than a second set that can drift from
-    them.
+    Each rule is (field, minimum, maximum, minimum_is_exclusive). Used to build
+    the validation step, so the ranges a reading is checked against are the
+    published ones rather than a second set that can drift from them.
+
+    The exclusivity flag is carried rather than flattened away. `capacity` is
+    declared `exclusiveMinimum: 0`, and treating that as inclusive lets a
+    zero-capacity message through - which divides to a null fill percentage and
+    kills the stateful query, since every fill rule compares that number
+    against a threshold.
     """
     rules = []
 
@@ -69,15 +76,32 @@ def range_rules() -> tuple[tuple[str, float | None, float | None], ...]:
         if spec["type"] != "number":
             continue
 
-        minimum = spec.get("minimum", spec.get("exclusiveMinimum"))
+        exclusive = spec.get("exclusiveMinimum")
+        minimum = spec.get("minimum", exclusive)
         maximum = spec.get("maximum")
 
         if minimum is None and maximum is None:
             continue
 
-        rules.append((name, minimum, maximum))
+        rules.append((name, minimum, maximum, exclusive is not None))
 
     return tuple(rules)
+
+
+@lru_cache
+def non_empty_fields() -> tuple[str, ...]:
+    """
+    String fields the contract says must carry at least one character.
+
+    Null is not the only way an identifier can be useless. An empty `bin_id`
+    parses, passes a null check, and then becomes a single shared state key
+    that unrelated malformed events all group under.
+    """
+    return tuple(
+        name
+        for name, spec in load_contract()["properties"].items()
+        if spec["type"] == "string" and spec.get("minLength", 0) > 0
+    )
 
 
 @lru_cache

--- a/services/stream-processor/src/schema.py
+++ b/services/stream-processor/src/schema.py
@@ -1,0 +1,86 @@
+"""The telemetry schema, built from the shared contract.
+
+Spark needs a fixed schema to read JSON from Kafka; inferring one from a stream
+is not possible. That fixed schema is the thing that silently breaks when the
+producer renames a field: Spark reads null for the missing column, every rule
+depending on it stops matching, and no job fails and nothing is logged.
+
+Building it from `contracts/telemetry-v1.json` rather than restating it here
+means the two services cannot disagree about the payload without the contract
+file itself changing, which is reviewable.
+"""
+
+import json
+from functools import lru_cache
+
+from pyspark.sql.types import DoubleType, StringType, StructField, StructType
+
+from config import get_settings
+
+# The contract is written in JSON Schema, whose type vocabulary is deliberately
+# small. Numbers are read as doubles throughout: fill levels and temperatures
+# are fractional, and reading an integral capacity as a double costs nothing.
+JSON_TYPE_TO_SPARK = {
+    "string": StringType(),
+    "number": DoubleType(),
+}
+
+# The event-time column, and the field the contract marks as a timestamp. It
+# arrives as an ISO 8601 string and is cast once, in the cleaning step.
+EVENT_TIME_FIELD = "timestamp"
+EVENT_TIME_COLUMN = "event_time"
+
+
+@lru_cache
+def load_contract() -> dict:
+    """Read and parse the shared telemetry contract."""
+    return json.loads(get_settings().CONTRACT_PATH.read_text())
+
+
+@lru_cache
+def telemetry_schema() -> StructType:
+    """The Spark schema for a telemetry message body.
+
+    Every field is nullable, which is deliberate: a message missing a field
+    should reach the validation step and be dead-lettered with a reason, rather
+    than failing to parse and being discarded with no explanation.
+    """
+    contract = load_contract()
+
+    return StructType(
+        [
+            StructField(name, JSON_TYPE_TO_SPARK[spec["type"]], nullable=True)
+            for name, spec in contract["properties"].items()
+        ]
+    )
+
+
+@lru_cache
+def range_rules() -> tuple[tuple[str, float | None, float | None], ...]:
+    """The numeric bounds the contract declares, as (field, minimum, maximum).
+
+    Used to build the validation step, so the ranges a reading is checked
+    against are the published ones rather than a second set that can drift from
+    them.
+    """
+    rules = []
+
+    for name, spec in load_contract()["properties"].items():
+        if spec["type"] != "number":
+            continue
+
+        minimum = spec.get("minimum", spec.get("exclusiveMinimum"))
+        maximum = spec.get("maximum")
+
+        if minimum is None and maximum is None:
+            continue
+
+        rules.append((name, minimum, maximum))
+
+    return tuple(rules)
+
+
+@lru_cache
+def required_fields() -> tuple[str, ...]:
+    """Fields a message must carry to be usable."""
+    return tuple(load_contract()["required"])

--- a/services/stream-processor/src/session.py
+++ b/services/stream-processor/src/session.py
@@ -1,0 +1,82 @@
+"""Spark session and Kafka source construction."""
+
+import logging
+
+from pyspark.sql import DataFrame, SparkSession
+
+from config import get_settings
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+def build_session() -> SparkSession:
+    """
+    Build the Spark session the streaming queries run in.
+
+    The two settings worth explaining:
+
+    RocksDB state store. Deduplicating over a ten minute watermark at a thousand
+    events a second holds several hundred thousand keys, and that is before the
+    per-bin state. The default provider keeps all of it on the JVM heap, so
+    garbage collection pauses grow with the state until the job stalls. RocksDB
+    spills to local disk instead, and changelog checkpointing means a restart
+    replays a change log rather than rebuilding every snapshot.
+
+    Local mode. A thousand events a second on one machine does not need a master
+    and workers, and skipping the cluster removes three containers and a network
+    from the deployment. This is the setting to revisit first when one machine
+    measurably runs out - not before.
+    """
+    session = (
+        SparkSession.builder.appName(settings.SPARK_APP_NAME)
+        .master(settings.SPARK_MASTER)
+        .config(
+            "spark.sql.streaming.stateStore.providerClass",
+            "org.apache.spark.sql.execution.streaming.state."
+            "RocksDBStateStoreProvider",
+        )
+        .config(
+            "spark.sql.streaming.stateStore.rocksdb.changelogCheckpointing.enabled",
+            "true",
+        )
+        # Local mode defaults to 200 shuffle partitions, which on a handful of
+        # cores means hundreds of near-empty tasks per micro-batch and more time
+        # spent scheduling than processing.
+        .config("spark.sql.shuffle.partitions", "12")
+        .config("spark.sql.session.timeZone", "UTC")
+        .getOrCreate()
+    )
+
+    session.sparkContext.setLogLevel("WARN")
+
+    logger.info(
+        "Spark %s session started on %s",
+        session.version,
+        settings.SPARK_MASTER,
+    )
+    return session
+
+
+def read_telemetry(session: SparkSession) -> DataFrame:
+    """
+    Open the raw telemetry stream.
+
+    Returns the Kafka records untouched - key, value and metadata - because the
+    cleaning step needs the raw bytes to forward anything unparseable to the
+    dead-letter topic. Parsing here would mean a malformed message was already
+    lost by the time anyone could act on it.
+    """
+    return (
+        session.readStream.format("kafka")
+        .option("kafka.bootstrap.servers", settings.KAFKA_BOOTSTRAP_SERVERS)
+        .option("subscribe", settings.KAFKA_TOPIC)
+        .option("startingOffsets", settings.STARTING_OFFSETS)
+        .option("maxOffsetsPerTrigger", settings.MAX_OFFSETS_PER_TRIGGER)
+        # A missing offset means the retention window passed while the job was
+        # down. Failing there requires a human to restart a job that cannot do
+        # anything but skip ahead; carrying on loses the same data either way
+        # and keeps the pipeline alive.
+        .option("failOnDataLoss", "false")
+        .load()
+    )

--- a/services/stream-processor/src/session.py
+++ b/services/stream-processor/src/session.py
@@ -28,7 +28,7 @@ def ensure_worker_interpreter() -> None:
     os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
 
 
-def build_session() -> SparkSession:
+def build_session(ui_port: int | None = None) -> SparkSession:
     """
     Build the Spark session the streaming queries run in.
 
@@ -45,8 +45,19 @@ def build_session() -> SparkSession:
     and workers, and skipping the cluster removes three containers and a network
     from the deployment. This is the setting to revisit first when one machine
     measurably runs out - not before.
+
+    Args:
+        ui_port:
+            Port for the Spark UI. Defaults to ``SPARK_UI_PORT``. The batch job
+            passes its own, because it runs alongside the streaming application
+            and would otherwise be pushed onto whichever port Spark found free -
+            a different address every run, announced by a warning that reads
+            like a fault.
     """
     ensure_worker_interpreter()
+
+    if ui_port is None:
+        ui_port = settings.SPARK_UI_PORT
 
     session = (
         SparkSession.builder.appName(settings.SPARK_APP_NAME)
@@ -65,15 +76,20 @@ def build_session() -> SparkSession:
         # spent scheduling than processing.
         .config("spark.sql.shuffle.partitions", "12")
         .config("spark.sql.session.timeZone", "UTC")
+        # Bound explicitly so the UI is always at a known address. Left to
+        # Spark's default retry, a busy port moves it silently.
+        .config("spark.ui.port", str(ui_port))
+        .config("spark.ui.portMaxRetries", "0")
         .getOrCreate()
     )
 
     session.sparkContext.setLogLevel("WARN")
 
     logger.info(
-        "Spark %s session started on %s",
+        "Spark %s session started on %s, UI on port %d",
         session.version,
         settings.SPARK_MASTER,
+        ui_port,
     )
     return session
 

--- a/services/stream-processor/src/session.py
+++ b/services/stream-processor/src/session.py
@@ -1,6 +1,8 @@
 """Spark session and Kafka source construction."""
 
 import logging
+import os
+import sys
 
 from pyspark.sql import DataFrame, SparkSession
 
@@ -8,6 +10,22 @@ from config import get_settings
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+
+def ensure_worker_interpreter() -> None:
+    """
+    Point Spark's Python workers at the interpreter that is driving them.
+
+    Spark launches workers as plain `python3` from PATH, which is not
+    necessarily the interpreter running this code. When it is not - inside a
+    virtual environment, most obviously - the workers start without pandas or
+    pyarrow and every pandas-based operator fails at run time with a bare import
+    error from inside a Spark stack trace, a long way from the actual cause.
+
+    Must be set before a session is created; it is read at worker launch.
+    """
+    os.environ.setdefault("PYSPARK_PYTHON", sys.executable)
+    os.environ.setdefault("PYSPARK_DRIVER_PYTHON", sys.executable)
 
 
 def build_session() -> SparkSession:
@@ -28,6 +46,8 @@ def build_session() -> SparkSession:
     from the deployment. This is the setting to revisit first when one machine
     measurably runs out - not before.
     """
+    ensure_worker_interpreter()
+
     session = (
         SparkSession.builder.appName(settings.SPARK_APP_NAME)
         .master(settings.SPARK_MASTER)

--- a/services/stream-processor/src/sinks.py
+++ b/services/stream-processor/src/sinks.py
@@ -33,6 +33,24 @@ def connect():
     return closing(psycopg2.connect(settings.DATABASE_URL))
 
 
+def schema_sql() -> str:
+    """
+    The schema file with the pipeline's thresholds filled in.
+
+    The dashboard views count the same things the detection rules alert on, so
+    hardcoding the numbers in both places let them disagree: the documented
+    demo profile drops the offline threshold to one minute, and the view went
+    on calling a bin active for the next fourteen. There is one source for
+    them, and this is where it reaches SQL.
+    """
+    return SCHEMA_PATH.read_text().format(
+        offline_minutes=settings.OFFLINE_AFTER_MINUTES,
+        critical_fill_pct=settings.CRITICAL_FILL_PCT,
+        overflow_fill_pct=settings.OVERFLOW_FILL_PCT,
+        low_battery_pct=settings.LOW_BATTERY_PCT,
+    )
+
+
 def apply_schema() -> None:
     """
     Create the output tables and views if they are not already there.
@@ -44,7 +62,7 @@ def apply_schema() -> None:
 
     with connect() as connection:
         with connection, connection.cursor() as cursor:
-            cursor.execute(SCHEMA_PATH.read_text())
+            cursor.execute(schema_sql())
 
     logger.info("Analytical schema applied")
 

--- a/services/stream-processor/src/sinks.py
+++ b/services/stream-processor/src/sinks.py
@@ -1,0 +1,147 @@
+"""Writing query output to PostgreSQL.
+
+Spark's built-in JDBC writer can only append or overwrite, and both are wrong
+here. A micro-batch is re-run after a failed write, so an append double-counts
+every retry, and an overwrite would discard history. What is needed is an upsert,
+which means going through the driver directly.
+
+Doing that with psycopg2 also removes the need for a JDBC driver jar in the
+image, so the only jars are the Kafka connector's.
+"""
+
+import logging
+from contextlib import closing
+from pathlib import Path
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+from config import get_settings
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "sql" / "schema.sql"
+
+
+def connect():
+    """Open a connection to the analytical database.
+
+    `with connection` commits or rolls back but does not close, so callers wrap
+    this in `closing` to avoid leaking a connection per micro-batch.
+    """
+    return closing(psycopg2.connect(settings.DATABASE_URL))
+
+
+def apply_schema() -> None:
+    """
+    Create the output tables and views if they are not already there.
+
+    Run once at startup. The schema file is written to be safe to re-run, so
+    this never destroys accumulated history.
+    """
+    logger.info("Applying analytical schema from %s", SCHEMA_PATH)
+
+    with connect() as connection:
+        with connection, connection.cursor() as cursor:
+            cursor.execute(SCHEMA_PATH.read_text())
+
+    logger.info("Analytical schema applied")
+
+
+def upsert(rows: list[tuple], table: str, columns: list[str], key: list[str]) -> None:
+    """
+    Insert rows, updating any that collide with an existing key.
+
+    Args:
+        rows:
+            Values to write, in the order given by ``columns``.
+
+        table:
+            Target table.
+
+        columns:
+            Column names being written.
+
+        key:
+            The conflicting columns, which must be a unique constraint on the
+            table.
+    """
+    if not rows:
+        return
+
+    updates = ", ".join(
+        f"{column} = EXCLUDED.{column}" for column in columns if column not in key
+    )
+
+    statement = (
+        f"INSERT INTO {table} ({', '.join(columns)}) VALUES %s "
+        f"ON CONFLICT ({', '.join(key)}) DO UPDATE SET {updates}"
+    )
+
+    with connect() as connection:
+        with connection, connection.cursor() as cursor:
+            execute_values(cursor, statement, rows, page_size=1000)
+
+    logger.debug("Upserted %d row(s) into %s", len(rows), table)
+
+
+def insert_ignoring_duplicates(
+    rows: list[tuple], table: str, columns: list[str], key: list[str]
+) -> None:
+    """
+    Insert rows, silently skipping any that already exist.
+
+    Used for facts that are true once and never revised - an alert that fired at
+    a particular instant does not later fire differently. Re-processing a batch
+    produces the identical rows, which are discarded rather than duplicated.
+    """
+    if not rows:
+        return
+
+    statement = (
+        f"INSERT INTO {table} ({', '.join(columns)}) VALUES %s "
+        f"ON CONFLICT ({', '.join(key)}) DO NOTHING"
+    )
+
+    with connect() as connection:
+        with connection, connection.cursor() as cursor:
+            execute_values(cursor, statement, rows, page_size=1000)
+
+    logger.debug("Inserted up to %d row(s) into %s", len(rows), table)
+
+
+def write_batch(dataframe, table: str, columns: list[str], key: list[str], mode: str):
+    """
+    Write one micro-batch to PostgreSQL.
+
+    Args:
+        dataframe:
+            The batch, whose columns must include every name in ``columns``.
+
+        table:
+            Target table.
+
+        columns:
+            Columns to write.
+
+        key:
+            Conflict key.
+
+        mode:
+            ``"upsert"`` to update existing rows, ``"ignore"`` to keep the
+            first version of each.
+    """
+    # Collected to the driver on purpose. A batch is at most one row per bin,
+    # which is thousands of rows, not millions - small enough that a single
+    # batched statement from the driver beats opening a connection per executor
+    # partition. Revisit if the fleet grows by orders of magnitude.
+    rows = [
+        tuple(row[column] for column in columns)
+        for row in dataframe.select(*columns).collect()
+    ]
+
+    if mode == "upsert":
+        upsert(rows, table, columns, key)
+    else:
+        insert_ignoring_duplicates(rows, table, columns, key)

--- a/services/stream-processor/tests/conftest.py
+++ b/services/stream-processor/tests/conftest.py
@@ -1,0 +1,95 @@
+import json
+import os
+
+import pytest
+
+# Set dummy environment variables for pydantic settings validation during tests
+os.environ.setdefault("POSTGRES_HOST", "localhost")
+os.environ.setdefault("POSTGRES_PORT", "5432")
+os.environ.setdefault("POSTGRES_DB", "test_db")
+os.environ.setdefault("POSTGRES_USER", "test_user")
+os.environ.setdefault("POSTGRES_PASSWORD", "test_password")
+os.environ.setdefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+os.environ.setdefault("KAFKA_TOPIC", "smartbin-telemetry-v1")
+
+
+@pytest.fixture(scope="session")
+def spark():
+    """A local Spark session shared by every test that needs one.
+
+    Starting a session costs seconds, so it is built once per run. One core and
+    one shuffle partition, because these tests process a handful of rows and the
+    default two hundred partitions would spend all their time on scheduling.
+
+    The pipeline's transformations are plain DataFrame functions, which behave
+    identically on a batch DataFrame and a streaming one. Testing them on batch
+    data keeps the tests fast and readable while exercising the real code.
+    """
+    from pyspark.sql import SparkSession
+
+    session = (
+        SparkSession.builder.appName("stream-processor-tests")
+        .master("local[1]")
+        .config("spark.sql.shuffle.partitions", "1")
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.ui.enabled", "false")
+        .getOrCreate()
+    )
+    session.sparkContext.setLogLevel("ERROR")
+
+    yield session
+
+    session.stop()
+
+
+@pytest.fixture
+def telemetry():
+    """A factory for well-formed telemetry payloads.
+
+    Defaults describe a healthy, half-full bin; pass overrides for the field
+    under test so each test states only what it is actually about.
+    """
+
+    def build(**overrides):
+        payload = {
+            "bin_id": "BIN-TEST-01",
+            "capacity": 100.0,
+            "current_fill_level": 50.0,
+            "battery_level": 80.0,
+            "temperature": 25.0,
+            "latitude": 17.4,
+            "longitude": 78.5,
+            "zone": "CENTRAL",
+            "timestamp": "2026-08-22T10:00:00+00:00",
+        }
+        payload.update(overrides)
+        return payload
+
+    return build
+
+
+@pytest.fixture
+def kafka_records(spark):
+    """Turn telemetry payloads into a DataFrame shaped like the Kafka source.
+
+    Accepts dicts, or raw strings for the messages that are meant to be
+    unparseable.
+    """
+
+    def build(*payloads):
+        rows = [
+            (
+                bytearray(
+                    (
+                        payload if isinstance(payload, str) else json.dumps(payload)
+                    ).encode()
+                ),
+                "smartbin-telemetry-v1",
+                0,
+                index,
+            )
+            for index, payload in enumerate(payloads)
+        ]
+        return spark.createDataFrame(rows, "value binary, topic string, partition int, offset long")
+
+    return build

--- a/services/stream-processor/tests/conftest.py
+++ b/services/stream-processor/tests/conftest.py
@@ -1,7 +1,19 @@
 import json
 import os
+from pathlib import Path
 
 import pytest
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+
+# Spark's Python workers are separate processes and inherit only the
+# environment, not pytest's import configuration. Without src on their path they
+# cannot import the module holding the function they were asked to run, and fail
+# with a bare ModuleNotFoundError from inside a Spark stack trace. The image
+# sets the same thing through PYTHONPATH.
+os.environ["PYTHONPATH"] = os.pathsep.join(
+    filter(None, [str(SERVICE_ROOT), str(SERVICE_ROOT / "src"), os.environ.get("PYTHONPATH")])
+)
 
 # Set dummy environment variables for pydantic settings validation during tests
 os.environ.setdefault("POSTGRES_HOST", "localhost")
@@ -26,6 +38,13 @@ def spark():
     data keeps the tests fast and readable while exercising the real code.
     """
     from pyspark.sql import SparkSession
+
+    from session import ensure_worker_interpreter
+
+    # Same call the service makes, for the same reason: without it Spark's
+    # workers launch under the system python rather than this virtual
+    # environment, and every pandas-based operator fails on a missing import.
+    ensure_worker_interpreter()
 
     session = (
         SparkSession.builder.appName("stream-processor-tests")

--- a/services/stream-processor/tests/test_bin_state.py
+++ b/services/stream-processor/tests/test_bin_state.py
@@ -1,7 +1,7 @@
 """Tests for Query 2 - the per-bin rules.
 
 The rules are plain Python over a dictionary of remembered values, so they are
-tested directly with no Spark session. That is deliberate: these ten rules carry
+tested directly with no Spark session. That is deliberate: these twelve rules carry
 almost all the behaviour anyone will argue about, and they should be readable and
 fast to check.
 
@@ -515,7 +515,7 @@ def test_a_bin_left_uncollected_breaches_its_sla():
         ),
     )
 
-    assert "SLA_BREACH" in fired
+    assert "SLA_BREACH_CRITICAL" in fired
 
 
 def test_a_bin_collected_in_time_does_not():
@@ -532,7 +532,7 @@ def test_a_bin_collected_in_time_does_not():
         ),
     )
 
-    assert "SLA_BREACH" not in fired
+    assert not [alert for alert in fired if alert.startswith("SLA_BREACH")]
 
 
 def test_an_overflowing_bin_is_on_a_shorter_clock():
@@ -548,7 +548,7 @@ def test_an_overflowing_bin_is_on_a_shorter_clock():
         ),
     )
 
-    assert "SLA_BREACH" in fired
+    assert "SLA_BREACH_OVERFLOW" in fired
 
 
 def test_an_sla_breach_is_reported_once():
@@ -563,7 +563,7 @@ def test_an_sla_breach_is_reported_once():
 
     fired = feed(memory, reading(fill_pct=85.0, event_ms=START_MS), *late)
 
-    assert fired.count("SLA_BREACH") == 1
+    assert fired.count("SLA_BREACH_CRITICAL") == 1
 
 
 # ---------------------------------------------------------------------------
@@ -717,3 +717,200 @@ def test_output_rows_match_the_declared_schema():
     out = run_operator(state, reading(fill_pct=85.0))
 
     assert list(out.columns) == OUTPUT_SCHEMA.fieldNames()
+
+
+# ---------------------------------------------------------------------------
+# Regressions found in review
+# ---------------------------------------------------------------------------
+
+
+def test_wobbling_across_the_threshold_does_not_re_alert():
+    """A dip below the line is not a collection, and must not read as one.
+
+    Clearing the fire-once flag on any reading under the threshold meant a bin
+    oscillating around 80% alerted on every crossing - and, worse, restarted
+    the SLA clock each time, so a bin nobody ever collected could stay inside
+    its SLA forever.
+    """
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=81.0, event_ms=START_MS),
+        reading(fill_pct=79.0, event_ms=START_MS + minutes(1)),
+        reading(fill_pct=81.0, event_ms=START_MS + minutes(2)),
+    )
+
+    assert fired.count("CRITICAL_FILL") == 1
+    assert memory["critical_since_ms"] == START_MS
+
+
+def test_wobbling_across_the_threshold_does_not_postpone_an_sla_breach():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=81.0, event_ms=START_MS),
+        reading(fill_pct=79.0, event_ms=START_MS + minutes(1)),
+        reading(
+            fill_pct=81.0,
+            event_ms=START_MS + minutes(settings.SLA_CRITICAL_MINUTES + 5),
+        ),
+    )
+
+    assert "SLA_BREACH_CRITICAL" in fired
+
+
+def test_wobbling_across_the_overflow_threshold_behaves_the_same():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=96.0, event_ms=START_MS),
+        reading(fill_pct=94.0, event_ms=START_MS + minutes(1)),
+        reading(fill_pct=96.0, event_ms=START_MS + minutes(2)),
+    )
+
+    assert fired.count("OVERFLOW") == 1
+    assert memory["overflow_since_ms"] == START_MS
+
+
+def test_a_full_bin_is_not_a_stuck_sensor():
+    """100% repeated is what a full bin looks like, not what a broken one does.
+
+    The simulator caps fill at capacity, so every bin waiting for a truck
+    reports exactly 100% each tick - the most ordinary state in the fleet, and
+    it was being reported as a hardware fault.
+    """
+    memory = fresh_memory()
+    full = [
+        reading(fill_pct=100.0, event_ms=START_MS + minutes(index))
+        for index in range(settings.STUCK_READING_COUNT + 5)
+    ]
+
+    assert "SENSOR_STUCK" not in feed(memory, *full)
+
+
+def test_a_sensor_frozen_at_empty_is_still_reported():
+    """Zero is not the mirror of 100%, and excluding it hid the FROZEN fault.
+
+    A full bin repeats 100% because the level is clamped at capacity. Nothing
+    clamps a bin at empty - waste accumulates - so a bin repeating 0% has a
+    sensor that stopped. Bins are seeded empty, so excluding zero suppressed
+    the alert for every frozen bin in the fleet, which an end-to-end run caught
+    and the unit tests did not.
+    """
+    memory = fresh_memory()
+    empty = [
+        reading(fill_pct=0.0, event_ms=START_MS + minutes(index))
+        for index in range(settings.STUCK_READING_COUNT + 5)
+    ]
+
+    assert "SENSOR_STUCK" in feed(memory, *empty)
+
+
+def test_a_frozen_sensor_between_the_rails_is_still_reported():
+    """The narrowing must not disable the detector it narrows."""
+    memory = fresh_memory()
+    same = [
+        reading(fill_pct=42.0, event_ms=START_MS + minutes(index))
+        for index in range(settings.STUCK_READING_COUNT + 2)
+    ]
+
+    assert "SENSOR_STUCK" in feed(memory, *same)
+
+
+def test_both_sla_clocks_breaching_at_once_produce_distinct_alerts():
+    """One alert type for both clocks collided in the database.
+
+    bin_alerts keys on (bin_id, alert_type, fired_at) and both breaches carry
+    the same event timestamp, so the second was silently discarded on insert.
+    """
+    memory = fresh_memory()
+    later = START_MS + minutes(settings.SLA_CRITICAL_MINUTES + 5)
+
+    evaluate_reading(memory, reading(fill_pct=97.0, event_ms=START_MS), BIN)
+    alerts = evaluate_reading(memory, reading(fill_pct=98.0, event_ms=later), BIN)
+
+    breaches = [alert for alert in alerts if alert["alert_type"].startswith("SLA_")]
+    keys = {(alert["bin_id"], alert["alert_type"], alert["fired_at"]) for alert in breaches}
+
+    assert len(breaches) == 2
+    # Same instant, so only the alert type keeps them apart in the table.
+    assert len({alert["fired_at"] for alert in breaches}) == 1
+    assert len(keys) == 2
+
+
+def test_a_second_failing_sensor_is_reported():
+    """One boolean for every sensor hid the second failure entirely."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(sensor_faults="temperature", event_ms=START_MS),
+        reading(
+            sensor_faults="temperature,battery_level",
+            event_ms=START_MS + minutes(1),
+        ),
+    )
+
+    assert fired.count("SENSOR_FAULT") == 2
+
+
+def test_the_same_failing_sensor_is_not_reported_twice():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(sensor_faults="temperature", event_ms=START_MS),
+        reading(sensor_faults="temperature", event_ms=START_MS + minutes(1)),
+        reading(sensor_faults="temperature", event_ms=START_MS + minutes(2)),
+    )
+
+    assert fired.count("SENSOR_FAULT") == 1
+
+
+def test_a_recovered_sensor_can_fail_again():
+    """Recovery clears the name, so the next failure is news again."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(sensor_faults="temperature", event_ms=START_MS),
+        reading(sensor_faults=None, event_ms=START_MS + minutes(1)),
+        reading(sensor_faults="temperature", event_ms=START_MS + minutes(2)),
+    )
+
+    assert fired.count("SENSOR_FAULT") == 2
+
+
+def test_the_state_row_records_when_it_was_written():
+    """updated_at is wall clock, last_seen is event time - both are needed.
+
+    Omitted from the written columns it kept its insert default forever, so it
+    reported when the bin was first seen and never moved again.
+    """
+    state = FakeGroupState()
+    frame = pd.DataFrame(
+        [
+            {
+                "bin_id": BIN,
+                "zone": "CENTRAL",
+                "capacity": 100.0,
+                "current_fill_level": 50.0,
+                "fill_pct": 50.0,
+                "battery_level": 80.0,
+                "temperature": 25.0,
+                "latitude": 17.4,
+                "longitude": 78.5,
+                "sensor_faults": None,
+                "event_time": pd.Timestamp(START_MS, unit="ms", tz="UTC"),
+            }
+        ]
+    )
+
+    rows = pd.concat(list(track_bin((BIN,), iter([frame]), state)))
+    states = rows[rows["record_type"] == RECORD_STATE]
+
+    assert len(states) == 1
+    assert states.iloc[0]["updated_at"] is not None

--- a/services/stream-processor/tests/test_bin_state.py
+++ b/services/stream-processor/tests/test_bin_state.py
@@ -42,6 +42,7 @@ def reading(**overrides):
         "battery_level": 80.0,
         "latitude": 17.4,
         "longitude": 78.5,
+        "sensor_faults": None,
         "event_ms": START_MS,
     }
     values.update(overrides)
@@ -436,6 +437,68 @@ def test_the_projection_arithmetic_is_right():
 
 
 # ---------------------------------------------------------------------------
+# Broken sensors
+# ---------------------------------------------------------------------------
+
+
+def test_a_broken_sensor_is_reported():
+    """The repair upstream must not be silent.
+
+    A bin whose thermometer died has its temperature nulled so the bin stays
+    trackable. Without this alert it would quietly stop contributing to fire
+    risk with nobody told - the same blind spot as discarding it, only harder
+    to see.
+    """
+    memory = fresh_memory()
+
+    assert "SENSOR_FAULT" in feed(memory, reading(sensor_faults="temperature"))
+
+
+def test_a_healthy_bin_reports_no_sensor_fault():
+    memory = fresh_memory()
+
+    assert "SENSOR_FAULT" not in feed(memory, reading())
+
+
+def test_a_broken_sensor_is_reported_once_not_every_reading():
+    """A permanently faulty sensor produces one alert, not a stream of them."""
+    memory = fresh_memory()
+    faulty = [
+        reading(sensor_faults="temperature", event_ms=START_MS + minutes(index))
+        for index in range(20)
+    ]
+
+    assert feed(memory, *faulty).count("SENSOR_FAULT") == 1
+
+
+def test_a_sensor_fault_can_be_reported_again_after_a_repair():
+    """Clearing when the sensor recovers is what makes firing once safe."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(sensor_faults="temperature", event_ms=START_MS),
+        reading(event_ms=START_MS + minutes(1)),
+        reading(sensor_faults="temperature", event_ms=START_MS + minutes(2)),
+    )
+
+    assert fired.count("SENSOR_FAULT") == 2
+
+
+def test_a_bin_with_a_broken_sensor_is_still_tracked():
+    """The whole point: it stays in the state store and keeps being watched.
+
+    It must still reach critical fill, and still arm its offline timeout.
+    """
+    memory = fresh_memory()
+
+    fired = feed(memory, reading(sensor_faults="temperature", fill_pct=85.0))
+
+    assert "CRITICAL_FILL" in fired
+    assert memory["last_fill_pct"] == 85.0
+
+
+# ---------------------------------------------------------------------------
 # SLA clocks
 # ---------------------------------------------------------------------------
 
@@ -522,6 +585,7 @@ def as_frame(*readings):
                 "temperature": values["temperature"],
                 "latitude": values["latitude"],
                 "longitude": values["longitude"],
+                "sensor_faults": values["sensor_faults"],
                 "event_time": pd.Timestamp(values["event_ms"], unit="ms", tz="UTC"),
             }
             for values in readings

--- a/services/stream-processor/tests/test_bin_state.py
+++ b/services/stream-processor/tests/test_bin_state.py
@@ -1,0 +1,655 @@
+"""Tests for Query 2 - the per-bin rules.
+
+The rules are plain Python over a dictionary of remembered values, so they are
+tested directly with no Spark session. That is deliberate: these ten rules carry
+almost all the behaviour anyone will argue about, and they should be readable and
+fast to check.
+
+Every rule gets both a positive case and the case that must NOT fire. A rule that
+fires on everything and a rule that fires correctly look identical if only the
+positive case is tested.
+"""
+
+import pandas as pd
+import pytest
+
+from config import get_settings
+from pipeline.bin_state import (
+    EMPTY_STATE,
+    OUTPUT_SCHEMA,
+    RECORD_ALERT,
+    RECORD_STATE,
+    STATE_FIELDS,
+    evaluate_reading,
+    fill_projection,
+    track_bin,
+)
+
+settings = get_settings()
+
+BIN = "BIN-TEST-01"
+START_MS = 1_755_000_000_000  # a fixed instant, so tests read deterministically
+
+
+def reading(**overrides):
+    """A healthy reading, with only what a test is about overridden."""
+    values = {
+        "zone": "CENTRAL",
+        "capacity": 100.0,
+        "current_fill_level": 50.0,
+        "fill_pct": 50.0,
+        "temperature": 25.0,
+        "battery_level": 80.0,
+        "latitude": 17.4,
+        "longitude": 78.5,
+        "event_ms": START_MS,
+    }
+    values.update(overrides)
+    return values
+
+
+def fresh_memory():
+    return dict(EMPTY_STATE)
+
+
+def feed(memory, *readings):
+    """Apply readings in order, returning every alert type raised."""
+    fired = []
+    for values in readings:
+        fired.extend(
+            alert["alert_type"] for alert in evaluate_reading(memory, values, BIN)
+        )
+    return fired
+
+
+def minutes(count):
+    return int(count * 60_000)
+
+
+class FakeGroupState:
+    """A stand-in for Spark's GroupState.
+
+    Small enough to be obviously correct, which is what makes it worth having:
+    it lets the whole operator be driven without a cluster.
+    """
+
+    def __init__(self, values=None, timed_out=False, watermark_ms=0):
+        self._values = values
+        self.hasTimedOut = timed_out
+        self._watermark_ms = watermark_ms
+        self.timeout_timestamp = None
+
+    @property
+    def exists(self):
+        return self._values is not None
+
+    @property
+    def get(self):
+        return self._values
+
+    def update(self, values):
+        self._values = values
+
+    def setTimeoutTimestamp(self, timestamp_ms):
+        self.timeout_timestamp = timestamp_ms
+
+    def getCurrentWatermarkMs(self):
+        return self._watermark_ms
+
+
+# ---------------------------------------------------------------------------
+# Critical fill - the collection list
+# ---------------------------------------------------------------------------
+
+
+def test_a_bin_over_the_threshold_goes_on_the_collection_list():
+    memory = fresh_memory()
+
+    assert "CRITICAL_FILL" in feed(memory, reading(fill_pct=85.0))
+
+
+def test_a_bin_under_the_threshold_does_not():
+    memory = fresh_memory()
+
+    assert "CRITICAL_FILL" not in feed(memory, reading(fill_pct=79.0))
+
+
+def test_critical_fill_fires_once_not_on_every_reading():
+    """The client asked for a collection list, not a stream of the same fact.
+
+    A bare filter would re-fire every few seconds for as long as the bin stayed
+    full - one bin stuck at 88% producing hundreds of identical alerts an hour.
+    """
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=85.0, event_ms=START_MS),
+        reading(fill_pct=86.0, event_ms=START_MS + minutes(1)),
+        reading(fill_pct=87.0, event_ms=START_MS + minutes(2)),
+        reading(fill_pct=88.0, event_ms=START_MS + minutes(3)),
+    )
+
+    assert fired.count("CRITICAL_FILL") == 1
+
+
+def test_critical_fill_can_fire_again_after_a_collection():
+    """Clearing on collection is what makes firing once safe."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=85.0, event_ms=START_MS),
+        reading(fill_pct=5.0, event_ms=START_MS + minutes(1)),
+        reading(fill_pct=85.0, event_ms=START_MS + minutes(60)),
+    )
+
+    assert fired.count("CRITICAL_FILL") == 2
+
+
+# ---------------------------------------------------------------------------
+# Overflow
+# ---------------------------------------------------------------------------
+
+
+def test_an_overflowing_bin_is_reported():
+    memory = fresh_memory()
+
+    assert "OVERFLOW" in feed(memory, reading(fill_pct=97.0))
+
+
+def test_a_merely_critical_bin_is_not_reported_as_overflowing():
+    memory = fresh_memory()
+
+    assert "OVERFLOW" not in feed(memory, reading(fill_pct=85.0))
+
+
+# ---------------------------------------------------------------------------
+# Collection
+# ---------------------------------------------------------------------------
+
+
+def test_a_large_drop_is_a_collection():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=90.0, event_ms=START_MS),
+        reading(fill_pct=5.0, event_ms=START_MS + minutes(1)),
+    )
+
+    assert "COLLECTED" in fired
+
+
+def test_a_small_drop_is_not_a_collection():
+    """Sensor noise and partial removals are not the truck arriving."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=50.0, event_ms=START_MS),
+        reading(fill_pct=45.0, event_ms=START_MS + minutes(1)),
+    )
+
+    assert "COLLECTED" not in fired
+
+
+def test_a_drop_from_a_low_level_is_not_a_collection():
+    """A bin that was never full cannot have been emptied by a truck."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=30.0, event_ms=START_MS),
+        reading(fill_pct=2.0, event_ms=START_MS + minutes(1)),
+    )
+
+    assert "COLLECTED" not in fired
+
+
+# ---------------------------------------------------------------------------
+# Abnormal jump
+# ---------------------------------------------------------------------------
+
+
+def test_a_sudden_rise_is_flagged():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=20.0, event_ms=START_MS),
+        reading(fill_pct=70.0, event_ms=START_MS + minutes(1)),
+    )
+
+    assert "ANOMALY_JUMP" in fired
+
+
+def test_normal_filling_is_not_flagged():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=20.0, event_ms=START_MS),
+        reading(fill_pct=21.0, event_ms=START_MS + minutes(1)),
+    )
+
+    assert "ANOMALY_JUMP" not in fired
+
+
+def test_the_first_ever_reading_is_never_a_jump():
+    """With nothing to compare against, a full bin is not a sudden rise."""
+    memory = fresh_memory()
+
+    assert "ANOMALY_JUMP" not in feed(memory, reading(fill_pct=95.0))
+
+
+# ---------------------------------------------------------------------------
+# Stuck sensor
+# ---------------------------------------------------------------------------
+
+
+def test_a_frozen_reading_is_eventually_reported():
+    memory = fresh_memory()
+    same = [
+        reading(fill_pct=42.0, event_ms=START_MS + minutes(index))
+        for index in range(settings.STUCK_READING_COUNT + 2)
+    ]
+
+    assert "SENSOR_STUCK" in feed(memory, *same)
+
+
+def test_a_stuck_sensor_is_reported_once_not_forever():
+    memory = fresh_memory()
+    same = [
+        reading(fill_pct=42.0, event_ms=START_MS + minutes(index))
+        for index in range(settings.STUCK_READING_COUNT * 3)
+    ]
+
+    assert feed(memory, *same).count("SENSOR_STUCK") == 1
+
+
+def test_a_bin_that_keeps_moving_is_not_stuck():
+    memory = fresh_memory()
+    moving = [
+        reading(fill_pct=10.0 + index, event_ms=START_MS + minutes(index))
+        for index in range(settings.STUCK_READING_COUNT * 2)
+    ]
+
+    assert "SENSOR_STUCK" not in feed(memory, *moving)
+
+
+# ---------------------------------------------------------------------------
+# Fire risk
+# ---------------------------------------------------------------------------
+
+
+def test_a_hot_full_bin_is_a_fire_risk():
+    memory = fresh_memory()
+
+    assert "FIRE_RISK" in feed(memory, reading(temperature=85.0, fill_pct=90.0))
+
+
+def test_a_hot_empty_bin_is_not_a_fire_risk():
+    """A hot empty bin is a warm day."""
+    memory = fresh_memory()
+
+    assert "FIRE_RISK" not in feed(memory, reading(temperature=85.0, fill_pct=10.0))
+
+
+def test_a_full_cool_bin_is_not_a_fire_risk():
+    """A full cool bin is just a full bin."""
+    memory = fresh_memory()
+
+    assert "FIRE_RISK" not in feed(memory, reading(temperature=25.0, fill_pct=95.0))
+
+
+def test_fire_risk_repeats_while_it_stays_true():
+    """Unlike the fire-once alerts: a fire does not stop being urgent.
+
+    It is still rate limited, so it does not fire on every reading.
+    """
+    memory = fresh_memory()
+    hot = [
+        reading(
+            temperature=85.0,
+            fill_pct=90.0,
+            event_ms=START_MS + minutes(index * settings.FIRE_RISK_REPEAT_MINUTES),
+        )
+        for index in range(4)
+    ]
+
+    assert feed(memory, *hot).count("FIRE_RISK") == 4
+
+
+def test_fire_risk_is_rate_limited_between_repeats():
+    memory = fresh_memory()
+    hot = [
+        reading(temperature=85.0, fill_pct=90.0, event_ms=START_MS + index * 5000)
+        for index in range(20)
+    ]
+
+    assert feed(memory, *hot).count("FIRE_RISK") == 1
+
+
+# ---------------------------------------------------------------------------
+# Low battery
+# ---------------------------------------------------------------------------
+
+
+def test_a_flat_battery_is_reported():
+    memory = fresh_memory()
+
+    assert "LOW_BATTERY" in feed(memory, reading(battery_level=15.0))
+
+
+def test_a_healthy_battery_is_not_reported():
+    memory = fresh_memory()
+
+    assert "LOW_BATTERY" not in feed(memory, reading(battery_level=50.0))
+
+
+def test_low_battery_fires_once_while_it_stays_low():
+    """Battery only falls, so without this it would alert until replaced."""
+    memory = fresh_memory()
+    draining = [
+        reading(battery_level=19.0 - index, event_ms=START_MS + minutes(index))
+        for index in range(10)
+    ]
+
+    assert feed(memory, *draining).count("LOW_BATTERY") == 1
+
+
+def test_low_battery_can_fire_again_after_a_replacement():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(battery_level=15.0, event_ms=START_MS),
+        reading(battery_level=100.0, event_ms=START_MS + minutes(1)),
+        reading(battery_level=15.0, event_ms=START_MS + minutes(2)),
+    )
+
+    assert fired.count("LOW_BATTERY") == 2
+
+
+# ---------------------------------------------------------------------------
+# Overflow prediction
+# ---------------------------------------------------------------------------
+
+
+def test_a_fast_filling_bin_is_predicted_to_overflow():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=30.0, event_ms=START_MS),
+        reading(fill_pct=55.0, event_ms=START_MS + minutes(10)),
+    )
+
+    assert "PREDICTED_OVERFLOW" in fired
+
+
+def test_a_slow_filling_bin_is_not():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=30.0, event_ms=START_MS),
+        reading(fill_pct=30.5, event_ms=START_MS + minutes(10)),
+    )
+
+    assert "PREDICTED_OVERFLOW" not in fired
+
+
+def test_an_emptying_bin_is_never_predicted_to_overflow():
+    """A negative rate projects to a nonsensical time and must not be used."""
+    rate, minutes_to_full = fill_projection(
+        previous_pct=90.0,
+        previous_ms=START_MS,
+        fill_pct=10.0,
+        event_ms=START_MS + minutes(5),
+    )
+
+    assert rate < 0
+    assert minutes_to_full is None
+
+
+def test_no_projection_from_a_single_reading():
+    """A rate needs two readings; one is not a trend."""
+    rate, minutes_to_full = fill_projection(None, 0, 50.0, START_MS)
+
+    assert rate is None
+    assert minutes_to_full is None
+
+
+def test_the_projection_arithmetic_is_right():
+    """Half full, rising two percent a minute, is full in twenty-five minutes."""
+    rate, minutes_to_full = fill_projection(
+        previous_pct=40.0,
+        previous_ms=START_MS,
+        fill_pct=50.0,
+        event_ms=START_MS + minutes(5),
+    )
+
+    assert rate == pytest.approx(2.0)
+    assert minutes_to_full == pytest.approx(25.0)
+
+
+# ---------------------------------------------------------------------------
+# SLA clocks
+# ---------------------------------------------------------------------------
+
+
+def test_a_bin_left_uncollected_breaches_its_sla():
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=85.0, event_ms=START_MS),
+        reading(
+            fill_pct=86.0,
+            event_ms=START_MS + minutes(settings.SLA_CRITICAL_MINUTES + 10),
+        ),
+    )
+
+    assert "SLA_BREACH" in fired
+
+
+def test_a_bin_collected_in_time_does_not():
+    """The clock is cleared by the collection, not by the bin emptying itself."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=85.0, event_ms=START_MS),
+        reading(fill_pct=5.0, event_ms=START_MS + minutes(10)),
+        reading(
+            fill_pct=20.0,
+            event_ms=START_MS + minutes(settings.SLA_CRITICAL_MINUTES + 30),
+        ),
+    )
+
+    assert "SLA_BREACH" not in fired
+
+
+def test_an_overflowing_bin_is_on_a_shorter_clock():
+    """Overflow gets thirty minutes where critical gets two hours."""
+    memory = fresh_memory()
+
+    fired = feed(
+        memory,
+        reading(fill_pct=97.0, event_ms=START_MS),
+        reading(
+            fill_pct=98.0,
+            event_ms=START_MS + minutes(settings.SLA_OVERFLOW_MINUTES + 5),
+        ),
+    )
+
+    assert "SLA_BREACH" in fired
+
+
+def test_an_sla_breach_is_reported_once():
+    memory = fresh_memory()
+    late = [
+        reading(
+            fill_pct=85.0,
+            event_ms=START_MS + minutes(settings.SLA_CRITICAL_MINUTES + index * 10),
+        )
+        for index in range(1, 6)
+    ]
+
+    fired = feed(memory, reading(fill_pct=85.0, event_ms=START_MS), *late)
+
+    assert fired.count("SLA_BREACH") == 1
+
+
+# ---------------------------------------------------------------------------
+# The operator as a whole
+# ---------------------------------------------------------------------------
+
+
+def as_frame(*readings):
+    """Readings shaped as the pandas frame Spark hands the operator."""
+    return pd.DataFrame(
+        [
+            {
+                "bin_id": BIN,
+                "zone": values["zone"],
+                "capacity": values["capacity"],
+                "current_fill_level": values["current_fill_level"],
+                "fill_pct": values["fill_pct"],
+                "battery_level": values["battery_level"],
+                "temperature": values["temperature"],
+                "latitude": values["latitude"],
+                "longitude": values["longitude"],
+                "event_time": pd.Timestamp(values["event_ms"], unit="ms", tz="UTC"),
+            }
+            for values in readings
+        ]
+    )
+
+
+def run_operator(state, *readings):
+    frames = [as_frame(*readings)] if readings else []
+    return pd.concat(list(track_bin((BIN,), iter(frames), state)), ignore_index=True)
+
+
+def test_the_operator_emits_one_state_row_per_batch():
+    """Downstream needs exactly one current-state row per bin, not one per event."""
+    state = FakeGroupState()
+
+    out = run_operator(
+        state,
+        reading(fill_pct=10.0, event_ms=START_MS),
+        reading(fill_pct=12.0, event_ms=START_MS + minutes(1)),
+        reading(fill_pct=14.0, event_ms=START_MS + minutes(2)),
+    )
+
+    assert (out.record_type == RECORD_STATE).sum() == 1
+
+
+def test_the_state_row_carries_the_latest_reading():
+    state = FakeGroupState()
+
+    out = run_operator(
+        state,
+        reading(fill_pct=10.0, event_ms=START_MS),
+        reading(fill_pct=14.0, event_ms=START_MS + minutes(2)),
+    )
+
+    latest = out[out.record_type == RECORD_STATE].iloc[0]
+    assert latest["fill_pct"] == 14.0
+
+
+def test_events_are_processed_in_time_order():
+    """Out of order, a rise reads as a drop and a collection is invented.
+
+    Spark makes no ordering promise within a batch, so the operator sorts.
+    """
+    state = FakeGroupState()
+
+    out = run_operator(
+        state,
+        reading(fill_pct=5.0, event_ms=START_MS + minutes(2)),
+        reading(fill_pct=90.0, event_ms=START_MS),
+    )
+
+    alerts = set(out[out.record_type == RECORD_ALERT].alert_type)
+    assert "COLLECTED" in alerts
+
+    latest = out[out.record_type == RECORD_STATE].iloc[0]
+    assert latest["fill_pct"] == 5.0
+
+
+def test_the_operator_arms_the_offline_timeout():
+    """Every batch re-arms the timer that becomes the offline alert."""
+    state = FakeGroupState()
+
+    run_operator(state, reading(event_ms=START_MS))
+
+    expected = START_MS + settings.OFFLINE_AFTER_MINUTES * 60_000
+    assert state.timeout_timestamp == expected
+
+
+def test_the_timeout_is_never_set_behind_the_watermark():
+    """Spark rejects a timeout already in the past, which a late event asks for."""
+    watermark = START_MS + minutes(600)
+    state = FakeGroupState(watermark_ms=watermark)
+
+    run_operator(state, reading(event_ms=START_MS))
+
+    assert state.timeout_timestamp > watermark
+
+
+def test_a_silent_bin_is_reported_offline():
+    """Dead-device detection is the timer firing, not a rule matching."""
+    memory = fresh_memory()
+    memory["zone"] = "CENTRAL"
+    memory["last_event_ms"] = START_MS
+    memory["last_fill_pct"] = 42.0
+    state = FakeGroupState(
+        values=tuple(memory[name] for name in STATE_FIELDS), timed_out=True
+    )
+
+    out = run_operator(state)
+
+    assert list(out.alert_type) == ["OFFLINE"]
+    assert out.iloc[0]["zone"] == "CENTRAL"
+
+
+def test_an_offline_alert_says_when_the_bin_was_last_seen():
+    """The useful part of the alert: not that it is gone, but since when."""
+    memory = fresh_memory()
+    memory["last_event_ms"] = START_MS
+    state = FakeGroupState(
+        values=tuple(memory[name] for name in STATE_FIELDS), timed_out=True
+    )
+
+    out = run_operator(state)
+
+    assert out.iloc[0]["last_seen"] == pd.Timestamp(START_MS, unit="ms", tz="UTC")
+
+
+def test_state_survives_a_round_trip_through_storage():
+    """What is written is what is read back, in the same order.
+
+    The state is a positional tuple, so a field added to the schema without the
+    dictionary matching would silently shift every value one place.
+    """
+    state = FakeGroupState()
+    run_operator(state, reading(fill_pct=61.0, event_ms=START_MS))
+
+    restored = dict(zip(STATE_FIELDS, state.get))
+
+    assert restored["last_fill_pct"] == 61.0
+    assert restored["zone"] == "CENTRAL"
+    assert restored["last_event_ms"] == START_MS
+
+
+def test_output_rows_match_the_declared_schema():
+    """Every emitted column is one Spark is expecting."""
+    state = FakeGroupState()
+
+    out = run_operator(state, reading(fill_pct=85.0))
+
+    assert list(out.columns) == OUTPUT_SCHEMA.fieldNames()

--- a/services/stream-processor/tests/test_clean.py
+++ b/services/stream-processor/tests/test_clean.py
@@ -83,11 +83,91 @@ def test_unparseable_message_is_rejected_not_dropped(kafka_records):
     assert "unparseable_or_missing_bin_id" in reasons[0]
 
 
-def test_impossible_temperature_is_rejected(kafka_records, telemetry):
-    """A reading no sensor could produce is not believed."""
-    reasons = rejections(kafka_records, telemetry(temperature=150.0))
+def test_impossible_temperature_does_not_discard_the_whole_reading(
+    kafka_records, telemetry
+):
+    """One dead sensor must not make the entire bin disappear.
 
-    assert any("temperature_above" in reason for reason in reasons)
+    Rejecting the whole message here was a monitoring blind spot: the bin never
+    reached the state store, so it vanished from every dashboard figure and
+    never armed an offline timeout either. A bin publishing every few seconds
+    became completely invisible, and the loudest sensor failure produced the
+    quietest outcome.
+    """
+    rows = valid_rows(kafka_records, telemetry(temperature=150.0))
+
+    assert len(rows) == 1
+    assert rows[0]["bin_id"] == "BIN-TEST-01"
+
+
+def test_an_impossible_temperature_is_nulled_not_kept(kafka_records, telemetry):
+    """The unusable reading itself is discarded, only the reading."""
+    rows = valid_rows(kafka_records, telemetry(temperature=150.0))
+
+    assert rows[0]["temperature"] is None
+
+
+def test_an_impossible_temperature_is_not_clamped(kafka_records, telemetry):
+    """Clamping would invent a plausible number no sensor reported.
+
+    120 C would then be averaged into the zone temperature as though it were a
+    real measurement. A null is honest that the reading is missing.
+    """
+    rows = valid_rows(kafka_records, telemetry(temperature=150.0))
+
+    assert rows[0]["temperature"] != 120.0
+
+
+def test_the_usable_readings_survive_a_broken_sensor(kafka_records, telemetry):
+    """Fill level is untouched by a thermometer failing."""
+    rows = valid_rows(
+        kafka_records,
+        telemetry(temperature=150.0, current_fill_level=87.0, battery_level=64.0),
+    )
+
+    assert rows[0]["current_fill_level"] == 87.0
+    assert rows[0]["battery_level"] == 64.0
+
+
+def test_the_broken_sensor_is_named(kafka_records, telemetry):
+    """The repair is recorded, so it can be alerted on rather than silent."""
+    rows = valid_rows(kafka_records, telemetry(temperature=150.0))
+
+    assert "temperature" in rows[0]["sensor_faults"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("battery_level", 140.0),
+        ("battery_level", -5.0),
+        ("latitude", 200.0),
+        ("longitude", -400.0),
+    ],
+)
+def test_every_repairable_sensor_is_handled(kafka_records, telemetry, field, value):
+    """Each sensor that can fail alone is nulled and named, in both directions."""
+    rows = valid_rows(kafka_records, telemetry(**{field: value}))
+
+    assert len(rows) == 1
+    assert rows[0][field] is None
+    assert field in rows[0]["sensor_faults"]
+
+
+def test_a_healthy_reading_reports_no_sensor_faults(kafka_records, telemetry):
+    """The negative case: nothing is flagged when nothing is wrong."""
+    rows = valid_rows(kafka_records, telemetry())
+
+    assert rows[0]["sensor_faults"] is None
+
+
+def test_several_broken_sensors_are_all_named(kafka_records, telemetry):
+    rows = valid_rows(
+        kafka_records, telemetry(temperature=150.0, battery_level=-5.0)
+    )
+
+    assert "temperature" in rows[0]["sensor_faults"]
+    assert "battery_level" in rows[0]["sensor_faults"]
 
 
 def test_a_hot_bin_is_believed(kafka_records, telemetry):
@@ -103,22 +183,19 @@ def test_a_hot_bin_is_believed(kafka_records, telemetry):
 
 
 @pytest.mark.parametrize(
-    ("field", "value", "expected"),
+    ("field", "value"),
     [
-        ("battery_level", 140.0, "battery_level_above"),
-        ("battery_level", -5.0, "battery_level_below"),
-        ("latitude", 200.0, "latitude_above"),
-        ("longitude", -400.0, "longitude_below"),
-        ("current_fill_level", -1.0, "current_fill_level_below"),
+        ("capacity", -1.0),
+        ("current_fill_level", -1.0),
     ],
 )
-def test_out_of_range_values_are_rejected(
-    kafka_records, telemetry, field, value, expected
+def test_out_of_range_tracking_fields_are_rejected(
+    kafka_records, telemetry, field, value
 ):
-    """Every contracted bound is enforced, in both directions."""
+    """A bound on a field the pipeline needs is fatal to the whole message."""
     reasons = rejections(kafka_records, telemetry(**{field: value}))
 
-    assert any(expected in reason for reason in reasons)
+    assert any(f"{field}_out_of_range" in reason for reason in reasons)
 
 
 def test_fill_level_above_capacity_is_rejected(kafka_records, telemetry):
@@ -134,7 +211,7 @@ def test_fill_level_above_capacity_is_rejected(kafka_records, telemetry):
     assert any("fill_level_exceeds_capacity" in reason for reason in reasons)
 
 
-def test_a_missing_field_is_named_in_the_reason(kafka_records, telemetry):
+def test_a_missing_tracking_field_is_named_in_the_reason(kafka_records, telemetry):
     """The reason says which field was absent."""
     payload = telemetry()
     del payload["zone"]
@@ -144,21 +221,36 @@ def test_a_missing_field_is_named_in_the_reason(kafka_records, telemetry):
     assert any("missing_zone" in reason for reason in reasons)
 
 
-def test_all_failing_checks_are_reported_together(kafka_records, telemetry):
-    """A reading gets every reason that applies, not just the first."""
-    reasons = rejections(
-        kafka_records, telemetry(temperature=500.0, battery_level=-10.0)
-    )
+def test_a_missing_sensor_reading_does_not_reject_the_message(
+    kafka_records, telemetry
+):
+    """An absent sensor is a fault to report, not a message to throw away."""
+    payload = telemetry()
+    del payload["temperature"]
 
-    assert "temperature_above" in reasons[0]
-    assert "battery_level_below" in reasons[0]
+    rows = valid_rows(kafka_records, payload)
+
+    assert len(rows) == 1
+    assert "temperature" in rows[0]["sensor_faults"]
+
+
+def test_all_failing_checks_are_reported_together(kafka_records, telemetry):
+    """A message gets every reason that applies, not just the first."""
+    payload = telemetry(capacity=-1.0)
+    del payload["zone"]
+
+    reasons = rejections(kafka_records, payload)
+
+    assert "missing_zone" in reasons[0]
+    assert "capacity_out_of_range" in reasons[0]
 
 
 def test_valid_and_rejected_partition_the_input(kafka_records, telemetry):
     """Every message ends up on exactly one side. Nothing is lost."""
     messages = [
         telemetry(bin_id="good-1"),
-        telemetry(bin_id="bad-1", temperature=999.0),
+        telemetry(bin_id="repairable", temperature=999.0),
+        telemetry(bin_id="fatal", current_fill_level=9999.0),
         "not json",
         telemetry(bin_id="good-2"),
     ]
@@ -166,7 +258,8 @@ def test_valid_and_rejected_partition_the_input(kafka_records, telemetry):
     parsed = parse(kafka_records(*messages))
     valid, rejected = split_valid_and_rejected(parsed)
 
-    assert valid.count() == 2
+    # The repairable one stays on the valid side, nulled rather than discarded
+    assert valid.count() == 3
     assert rejected.count() == 2
 
 
@@ -209,12 +302,14 @@ def test_fill_pct_is_computed_from_capacity(
 
 def test_dead_letter_carries_the_reason_and_the_original(kafka_records, telemetry):
     """A dead letter is actionable: it says why, and includes what arrived."""
-    rows = dead_letters(kafka_records(telemetry(temperature=999.0))).collect()
+    rows = dead_letters(
+        kafka_records(telemetry(current_fill_level=9999.0))
+    ).collect()
 
     assert len(rows) == 1
     envelope = json.loads(rows[0]["value"])
 
-    assert "temperature_above" in envelope["reason"]
+    assert "fill_level_exceeds_capacity" in envelope["reason"]
     assert envelope["source_partition"] == 0
     assert json.loads(envelope["payload"])["bin_id"] == "BIN-TEST-01"
 
@@ -236,7 +331,9 @@ def test_dead_letter_envelope_survives_a_hostile_payload(kafka_records):
 
 def test_dead_letter_is_keyed_by_bin_where_known(kafka_records, telemetry):
     """Keying by bin keeps one bin's bad messages together on one partition."""
-    rows = dead_letters(kafka_records(telemetry(battery_level=500.0))).collect()
+    rows = dead_letters(
+        kafka_records(telemetry(current_fill_level=9999.0))
+    ).collect()
 
     assert rows[0]["key"] == "BIN-TEST-01"
 

--- a/services/stream-processor/tests/test_clean.py
+++ b/services/stream-processor/tests/test_clean.py
@@ -353,7 +353,7 @@ def test_dead_letter_key_falls_back_when_the_bin_is_unknown(kafka_records):
 def test_history_is_partitioned_by_event_date(spark, kafka_records, telemetry):
     """The history carries the date column it is partitioned by.
 
-    Partitioning by date is what lets the nightly job read one day without
+    Partitioning by date is what lets the batch job read one day without
     scanning the whole history.
     """
     parsed = parse(kafka_records(telemetry()))
@@ -370,3 +370,59 @@ def test_clean_columns_are_what_downstream_queries_expect():
     """The published column list contains everything the rules need."""
     for needed in ("bin_id", "zone", "fill_pct", "temperature", "battery_level"):
         assert needed in CLEAN_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# Regressions found in review
+# ---------------------------------------------------------------------------
+
+
+def test_a_zero_capacity_reading_is_rejected(kafka_records, telemetry):
+    """The contract says capacity is greater than zero, and it must be enforced.
+
+    Accepted, it divides to a null fill percentage, and every fill rule in the
+    stateful operator compares that null against a threshold - which raises in
+    the Python worker and takes the whole streaming application down. One
+    message was enough.
+    """
+    reasons = rejections(kafka_records, telemetry(capacity=0.0))
+
+    assert "capacity_out_of_range" in reasons[0]
+
+
+def test_a_positive_capacity_is_still_accepted(kafka_records, telemetry):
+    """The exclusive bound must reject zero without rejecting small bins."""
+    rows = valid_rows(kafka_records, telemetry(capacity=0.5, current_fill_level=0.25))
+
+    assert len(rows) == 1
+    assert rows[0]["capacity"] == 0.5
+
+
+def test_an_empty_bin_id_is_rejected(kafka_records, telemetry):
+    """Empty is not null, and it passed every null check.
+
+    All such events then group under one empty key in the stateful operator, so
+    unrelated bins share a single state entry.
+    """
+    reasons = rejections(kafka_records, telemetry(bin_id=""))
+
+    assert "empty_bin_id" in reasons[0]
+
+
+def test_a_whitespace_zone_is_rejected(kafka_records, telemetry):
+    reasons = rejections(kafka_records, telemetry(zone="   "))
+
+    assert "empty_zone" in reasons[0]
+
+
+def test_no_valid_reading_can_divide_to_a_null_fill_percentage(kafka_records, telemetry):
+    """The one guarantee the stateful operator relies on and cannot check.
+
+    fill_pct is computed as a guarded division, so a capacity of zero would
+    reach the operator as a null. Validation is what makes that unreachable.
+    """
+    rows = valid_rows(
+        kafka_records, telemetry(), telemetry(capacity=240.0), telemetry(capacity=0.0)
+    )
+
+    assert all(row["capacity"] > 0 for row in rows)

--- a/services/stream-processor/tests/test_clean.py
+++ b/services/stream-processor/tests/test_clean.py
@@ -1,0 +1,275 @@
+"""Tests for Query 1 - parsing, validation and the dead-letter path.
+
+The transformations under test are plain DataFrame functions, so they behave
+identically on the batch DataFrames used here and on the real stream. The one
+exception is deduplication, which needs a watermark and therefore a streaming
+DataFrame; it is covered separately at the end.
+"""
+
+import json
+
+import pytest
+from pyspark.sql.functions import col
+
+from pipeline.clean import (
+    CLEAN_COLUMNS,
+    dead_letters,
+    parse,
+    partitioned_by_date,
+    split_valid_and_rejected,
+)
+
+
+def valid_rows(kafka_records, *payloads):
+    """The believable readings out of a set of messages."""
+    valid, _ = split_valid_and_rejected(parse(kafka_records(*payloads)))
+    return valid.collect()
+
+
+def rejections(kafka_records, *payloads):
+    """The reject reasons produced by a set of messages."""
+    _, rejected = split_valid_and_rejected(parse(kafka_records(*payloads)))
+    return [row["reject_reason"] for row in rejected.collect()]
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_a_healthy_reading_is_parsed_and_kept(kafka_records, telemetry):
+    """A well-formed message survives validation with its values intact."""
+    rows = valid_rows(kafka_records, telemetry())
+
+    assert len(rows) == 1
+    assert rows[0]["bin_id"] == "BIN-TEST-01"
+    assert rows[0]["zone"] == "CENTRAL"
+    assert rows[0]["temperature"] == 25.0
+
+
+def test_the_timestamp_becomes_a_real_event_time(kafka_records, telemetry):
+    """The ISO string is cast to a timestamp, which windowing depends on."""
+    rows = valid_rows(kafka_records, telemetry())
+
+    assert rows[0]["event_time"] is not None
+    assert rows[0]["event_time"].year == 2026
+
+
+def test_zone_arrives_without_any_database_lookup(kafka_records, telemetry):
+    """Zone travels on the event, so the stream needs no join to enrich it.
+
+    This is what removes the bins table from the hot path, and with it the case
+    where a bin registered after the job started is enriched with nulls.
+    """
+    rows = valid_rows(kafka_records, telemetry(zone="NORTH"))
+
+    assert rows[0]["zone"] == "NORTH"
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_unparseable_message_is_rejected_not_dropped(kafka_records):
+    """Malformed JSON is dead-lettered with a reason rather than discarded.
+
+    Discarding it silently would be indistinguishable from the bin never having
+    sent anything - which is exactly what dead-device detection looks for.
+    """
+    reasons = rejections(kafka_records, "this is not json at all")
+
+    assert len(reasons) == 1
+    assert "unparseable_or_missing_bin_id" in reasons[0]
+
+
+def test_impossible_temperature_is_rejected(kafka_records, telemetry):
+    """A reading no sensor could produce is not believed."""
+    reasons = rejections(kafka_records, telemetry(temperature=150.0))
+
+    assert any("temperature_above" in reason for reason in reasons)
+
+
+def test_a_hot_bin_is_believed(kafka_records, telemetry):
+    """A dangerous but physically possible temperature is kept.
+
+    The counterpart to the test above: if validation rejected these, fire risk
+    detection would never see the readings it exists to act on.
+    """
+    rows = valid_rows(kafka_records, telemetry(temperature=85.0))
+
+    assert len(rows) == 1
+    assert rows[0]["temperature"] == 85.0
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("battery_level", 140.0, "battery_level_above"),
+        ("battery_level", -5.0, "battery_level_below"),
+        ("latitude", 200.0, "latitude_above"),
+        ("longitude", -400.0, "longitude_below"),
+        ("current_fill_level", -1.0, "current_fill_level_below"),
+    ],
+)
+def test_out_of_range_values_are_rejected(
+    kafka_records, telemetry, field, value, expected
+):
+    """Every contracted bound is enforced, in both directions."""
+    reasons = rejections(kafka_records, telemetry(**{field: value}))
+
+    assert any(expected in reason for reason in reasons)
+
+
+def test_fill_level_above_capacity_is_rejected(kafka_records, telemetry):
+    """A bin cannot hold more than it holds.
+
+    A relationship between two fields rather than a bound on one, so it cannot
+    be expressed in the contract's per-field ranges.
+    """
+    reasons = rejections(
+        kafka_records, telemetry(capacity=100.0, current_fill_level=150.0)
+    )
+
+    assert any("fill_level_exceeds_capacity" in reason for reason in reasons)
+
+
+def test_a_missing_field_is_named_in_the_reason(kafka_records, telemetry):
+    """The reason says which field was absent."""
+    payload = telemetry()
+    del payload["zone"]
+
+    reasons = rejections(kafka_records, payload)
+
+    assert any("missing_zone" in reason for reason in reasons)
+
+
+def test_all_failing_checks_are_reported_together(kafka_records, telemetry):
+    """A reading gets every reason that applies, not just the first."""
+    reasons = rejections(
+        kafka_records, telemetry(temperature=500.0, battery_level=-10.0)
+    )
+
+    assert "temperature_above" in reasons[0]
+    assert "battery_level_below" in reasons[0]
+
+
+def test_valid_and_rejected_partition_the_input(kafka_records, telemetry):
+    """Every message ends up on exactly one side. Nothing is lost."""
+    messages = [
+        telemetry(bin_id="good-1"),
+        telemetry(bin_id="bad-1", temperature=999.0),
+        "not json",
+        telemetry(bin_id="good-2"),
+    ]
+
+    parsed = parse(kafka_records(*messages))
+    valid, rejected = split_valid_and_rejected(parsed)
+
+    assert valid.count() == 2
+    assert rejected.count() == 2
+
+
+# ---------------------------------------------------------------------------
+# Fill percentage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("capacity", "level", "expected"),
+    [(100.0, 50.0, 50.0), (240.0, 60.0, 25.0), (660.0, 594.0, 90.0)],
+)
+def test_fill_pct_is_computed_from_capacity(
+    spark, kafka_records, telemetry, capacity, level, expected
+):
+    """Fill percentage accounts for the size of the bin.
+
+    Every threshold downstream is a percentage while the payload carries an
+    absolute level, so a 660 litre bin at 594 litres has to read as 90% full and
+    not as an impossible 594%.
+    """
+    from pipeline.clean import parse as parse_records
+
+    parsed = parse_records(
+        kafka_records(telemetry(capacity=capacity, current_fill_level=level))
+    )
+    valid, _ = split_valid_and_rejected(parsed)
+
+    row = valid.withColumn(
+        "fill_pct", col("current_fill_level") / col("capacity") * 100
+    ).collect()[0]
+
+    assert row["fill_pct"] == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Dead letters
+# ---------------------------------------------------------------------------
+
+
+def test_dead_letter_carries_the_reason_and_the_original(kafka_records, telemetry):
+    """A dead letter is actionable: it says why, and includes what arrived."""
+    rows = dead_letters(kafka_records(telemetry(temperature=999.0))).collect()
+
+    assert len(rows) == 1
+    envelope = json.loads(rows[0]["value"])
+
+    assert "temperature_above" in envelope["reason"]
+    assert envelope["source_partition"] == 0
+    assert json.loads(envelope["payload"])["bin_id"] == "BIN-TEST-01"
+
+
+def test_dead_letter_envelope_survives_a_hostile_payload(kafka_records):
+    """A payload full of quotes and backslashes does not break the envelope.
+
+    Unparseable messages are exactly the ones likely to contain whatever would
+    corrupt a hand-assembled JSON string, which is why the envelope is built
+    with a real JSON writer.
+    """
+    hostile = '{"bin_id": "x\\", "note": "he said \\"hi\\"", '
+
+    rows = dead_letters(kafka_records(hostile)).collect()
+
+    envelope = json.loads(rows[0]["value"])
+    assert envelope["payload"] == hostile
+
+
+def test_dead_letter_is_keyed_by_bin_where_known(kafka_records, telemetry):
+    """Keying by bin keeps one bin's bad messages together on one partition."""
+    rows = dead_letters(kafka_records(telemetry(battery_level=500.0))).collect()
+
+    assert rows[0]["key"] == "BIN-TEST-01"
+
+
+def test_dead_letter_key_falls_back_when_the_bin_is_unknown(kafka_records):
+    """A message too broken to name a bin still gets published."""
+    rows = dead_letters(kafka_records("garbage")).collect()
+
+    assert rows[0]["key"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Parquet layout
+# ---------------------------------------------------------------------------
+
+
+def test_history_is_partitioned_by_event_date(spark, kafka_records, telemetry):
+    """The history carries the date column it is partitioned by.
+
+    Partitioning by date is what lets the nightly job read one day without
+    scanning the whole history.
+    """
+    parsed = parse(kafka_records(telemetry()))
+    valid, _ = split_valid_and_rejected(parsed)
+    dated = partitioned_by_date(
+        valid.withColumn("fill_pct", col("current_fill_level"))
+    )
+
+    assert "event_date" in dated.columns
+    assert str(dated.collect()[0]["event_date"]) == "2026-08-22"
+
+
+def test_clean_columns_are_what_downstream_queries_expect():
+    """The published column list contains everything the rules need."""
+    for needed in ("bin_id", "zone", "fill_pct", "temperature", "battery_level"):
+        assert needed in CLEAN_COLUMNS

--- a/services/stream-processor/tests/test_rollups.py
+++ b/services/stream-processor/tests/test_rollups.py
@@ -1,4 +1,4 @@
-"""Tests for the nightly rollup job.
+"""Tests for the rollup job.
 
 These run on batch DataFrames because the job itself is batch - there is nothing
 to simulate. The window function is the part worth checking carefully: it
@@ -241,3 +241,49 @@ def test_daily_trend_reports_the_peak_not_only_the_average(history):
 
     assert day["avg_fill_pct"] == pytest.approx(54.0)
     assert day["max_fill_pct"] == pytest.approx(98.0)
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_history_is_not_a_failure(monkeypatch, tmp_path):
+    """The first run happens before the streaming pipeline has written anything."""
+    from batch import rollups
+
+    monkeypatch.setattr(rollups.settings, "PARQUET_PATH", str(tmp_path / "absent"))
+    monkeypatch.setattr(
+        rollups, "build_session", lambda **_: pytest.fail("should not start Spark")
+    )
+
+    assert rollups.main() is None
+
+
+def test_an_unreadable_history_fails_loudly(monkeypatch, tmp_path, spark):
+    """Anything other than an absent directory has to reach the exit code.
+
+    Reported as "no history" and exited zero, a corrupt or unreadable history
+    left the analytical tables silently stale, with nothing for a scheduler to
+    retry and nothing for monitoring to notice.
+    """
+    from batch import rollups
+
+    history = tmp_path / "history"
+    history.mkdir()
+    (history / "part-0.parquet").write_text("this is not parquet")
+
+    # The job stops its session in a finally, and the session here is shared
+    # with every other test in the run - so it is handed one that ignores that.
+    class KeepAlive:
+        def __getattr__(self, name):
+            return getattr(spark, name)
+
+        def stop(self):
+            pass
+
+    monkeypatch.setattr(rollups.settings, "PARQUET_PATH", str(history))
+    monkeypatch.setattr(rollups, "build_session", lambda **_: KeepAlive())
+
+    with pytest.raises(Exception):
+        rollups.main()

--- a/services/stream-processor/tests/test_rollups.py
+++ b/services/stream-processor/tests/test_rollups.py
@@ -1,0 +1,243 @@
+"""Tests for the nightly rollup job.
+
+These run on batch DataFrames because the job itself is batch - there is nothing
+to simulate. The window function is the part worth checking carefully: it
+compares each reading against the previous one for the same bin, and getting
+either the partitioning or the ordering wrong produces numbers that look
+plausible and are wrong.
+"""
+
+import datetime
+
+import pytest
+
+from batch.rollups import daily_trend, hourly_profile, with_fill_rate
+
+SCHEMA = (
+    "bin_id string, zone string, fill_pct double, temperature double, "
+    "event_time timestamp"
+)
+
+
+def at(hour, minute=0, day=22):
+    return datetime.datetime(2026, 8, day, hour, minute, tzinfo=datetime.timezone.utc)
+
+
+def by_fill(rows):
+    """Index collected rows by their fill level.
+
+    Keyed on fill level rather than on the timestamp because Spark returns
+    timestamps as naive datetimes in the driver's local zone, so comparing them
+    against the tz-aware values used to build the input silently matches
+    nothing.
+    """
+    return {row["fill_pct"]: row for row in rows}
+
+
+@pytest.fixture
+def history(spark):
+    """Build an event history from (bin, zone, fill_pct, temperature, time)."""
+
+    def build(rows):
+        return spark.createDataFrame(rows, SCHEMA)
+
+    return build
+
+
+# ---------------------------------------------------------------------------
+# Fill rate
+# ---------------------------------------------------------------------------
+
+
+def test_fill_rate_is_per_hour(history):
+    """Ten percent over two hours is five percent an hour."""
+    rated = with_fill_rate(
+        history(
+            [
+                ("BIN-A", "CENTRAL", 10.0, 25.0, at(1)),
+                ("BIN-A", "CENTRAL", 20.0, 25.0, at(3)),
+            ]
+        )
+    ).collect()
+
+    assert by_fill(rated)[20.0]["fill_rate_pct_hour"] == pytest.approx(5.0)
+
+
+def test_the_first_reading_has_no_rate(history):
+    """A rate needs two readings; one is not a trend."""
+    rated = with_fill_rate(
+        history([("BIN-A", "CENTRAL", 10.0, 25.0, at(1))])
+    ).collect()
+
+    assert rated[0]["fill_rate_pct_hour"] is None
+
+
+def test_bins_are_never_compared_against_each_other(history):
+    """The window is partitioned by bin.
+
+    Without that, one bin's first reading is compared against another bin's
+    last, inventing enormous rates out of nothing.
+    """
+    rated = with_fill_rate(
+        history(
+            [
+                ("BIN-A", "CENTRAL", 90.0, 25.0, at(1)),
+                ("BIN-B", "CENTRAL", 10.0, 25.0, at(2)),
+            ]
+        )
+    ).collect()
+
+    first_of_b = [row for row in rated if row["bin_id"] == "BIN-B"][0]
+    assert first_of_b["fill_rate_pct_hour"] is None
+
+
+def test_readings_are_compared_in_time_order(history):
+    """Ordering is by event time, not by the order rows happen to be read."""
+    rated = with_fill_rate(
+        history(
+            [
+                ("BIN-A", "CENTRAL", 30.0, 25.0, at(5)),
+                ("BIN-A", "CENTRAL", 10.0, 25.0, at(1)),
+                ("BIN-A", "CENTRAL", 20.0, 25.0, at(3)),
+            ]
+        )
+    ).collect()
+
+    by_level = by_fill(rated)
+    assert by_level[20.0]["prev_fill_pct"] == 10.0
+    assert by_level[30.0]["prev_fill_pct"] == 20.0
+
+
+def test_emptying_does_not_count_as_a_fill_rate(history):
+    """A drop is the bin being collected, not it filling backwards.
+
+    Averaging drops in would report the zones that are collected most often as
+    the ones filling most slowly, which is exactly backwards.
+    """
+    rated = with_fill_rate(
+        history(
+            [
+                ("BIN-A", "CENTRAL", 90.0, 25.0, at(1)),
+                ("BIN-A", "CENTRAL", 5.0, 25.0, at(2)),
+            ]
+        )
+    ).collect()
+
+    assert by_fill(rated)[5.0]["fill_rate_pct_hour"] is None
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+def test_a_large_drop_counts_as_a_collection(history):
+    rated = with_fill_rate(
+        history(
+            [
+                ("BIN-A", "CENTRAL", 90.0, 25.0, at(1)),
+                ("BIN-A", "CENTRAL", 5.0, 25.0, at(2)),
+            ]
+        )
+    ).collect()
+
+    assert sum(row["collected"] for row in rated) == 1
+
+
+def test_a_small_drop_does_not(history):
+    rated = with_fill_rate(
+        history(
+            [
+                ("BIN-A", "CENTRAL", 50.0, 25.0, at(1)),
+                ("BIN-A", "CENTRAL", 45.0, 25.0, at(2)),
+            ]
+        )
+    ).collect()
+
+    assert sum(row["collected"] for row in rated) == 0
+
+
+# ---------------------------------------------------------------------------
+# Rollups
+# ---------------------------------------------------------------------------
+
+
+def test_hourly_profile_finds_the_busy_hour(history):
+    """The point of the whole job: which hour a zone fills fastest."""
+    rows = [
+        ("BIN-A", "CENTRAL", 10.0, 25.0, at(3)),
+        ("BIN-A", "CENTRAL", 12.0, 25.0, at(4)),  # +2 in an hour
+        ("BIN-A", "CENTRAL", 42.0, 25.0, at(5)),  # +30 in an hour
+    ]
+
+    profile = {
+        row["hour_of_day"]: row
+        for row in hourly_profile(with_fill_rate(history(rows))).collect()
+    }
+
+    assert profile[5]["avg_fill_rate_pct_hour"] > profile[4]["avg_fill_rate_pct_hour"]
+
+
+def test_hourly_profile_is_split_by_zone(history):
+    rows = [
+        ("BIN-A", "CENTRAL", 10.0, 25.0, at(3)),
+        ("BIN-A", "CENTRAL", 12.0, 25.0, at(4)),
+        ("BIN-B", "NORTH", 10.0, 25.0, at(3)),
+        ("BIN-B", "NORTH", 40.0, 25.0, at(4)),
+    ]
+
+    zones = {row["zone"] for row in hourly_profile(with_fill_rate(history(rows))).collect()}
+
+    assert zones == {"CENTRAL", "NORTH"}
+
+
+def test_daily_trend_counts_distinct_bins_not_readings(history):
+    """Two bins reporting five times each is two bins, not ten."""
+    rows = [
+        (f"BIN-{index % 2}", "CENTRAL", 10.0 + index, 25.0, at(1 + index))
+        for index in range(10)
+    ]
+
+    day = daily_trend(with_fill_rate(history(rows))).collect()[0]
+
+    assert day["bins_reporting"] == 2
+
+
+def test_daily_trend_totals_collections(history):
+    rows = [
+        ("BIN-A", "CENTRAL", 90.0, 25.0, at(1)),
+        ("BIN-A", "CENTRAL", 5.0, 25.0, at(2)),
+        ("BIN-A", "CENTRAL", 95.0, 25.0, at(6)),
+        ("BIN-A", "CENTRAL", 2.0, 25.0, at(7)),
+    ]
+
+    day = daily_trend(with_fill_rate(history(rows))).collect()[0]
+
+    assert day["collections"] == 2
+
+
+def test_daily_trend_separates_days(history):
+    rows = [
+        ("BIN-A", "CENTRAL", 10.0, 25.0, at(1, day=22)),
+        ("BIN-A", "CENTRAL", 20.0, 25.0, at(1, day=23)),
+    ]
+
+    days = {str(row["day"]) for row in daily_trend(with_fill_rate(history(rows))).collect()}
+
+    assert days == {"2026-08-22", "2026-08-23"}
+
+
+def test_daily_trend_reports_the_peak_not_only_the_average(history):
+    """An average hides the thing operations care about.
+
+    A zone averaging 45% while one of its bins sat at 98% is not a calm zone.
+    """
+    rows = [
+        ("BIN-A", "CENTRAL", 10.0, 25.0, at(1)),
+        ("BIN-B", "CENTRAL", 98.0, 25.0, at(1)),
+    ]
+
+    day = daily_trend(with_fill_rate(history(rows))).collect()[0]
+
+    assert day["avg_fill_pct"] == pytest.approx(54.0)
+    assert day["max_fill_pct"] == pytest.approx(98.0)

--- a/services/stream-processor/tests/test_schema.py
+++ b/services/stream-processor/tests/test_schema.py
@@ -46,7 +46,7 @@ def test_every_field_is_nullable():
 
 def test_range_rules_cover_the_fields_with_bounds():
     """The bounds used for validation come from the contract."""
-    rules = dict((name, (low, high)) for name, low, high in range_rules())
+    rules = dict((name, (low, high)) for name, low, high, _ in range_rules())
 
     assert rules["battery_level"] == (0, 100)
     assert rules["latitude"] == (-90, 90)
@@ -60,7 +60,7 @@ def test_temperature_range_admits_a_fire_risk_reading():
     precisely the condition the fire rule looks for - and the rule would then
     never fire, with the readings discarded as impossible upstream.
     """
-    rules = dict((name, (low, high)) for name, low, high in range_rules())
+    rules = dict((name, (low, high)) for name, low, high, _ in range_rules())
 
     assert rules["temperature"][1] > 70
 
@@ -82,3 +82,41 @@ def test_the_batch_job_does_not_take_the_streaming_ui_port():
     settings = get_settings()
 
     assert settings.SPARK_UI_PORT != settings.SPARK_BATCH_UI_PORT
+
+
+def test_the_capacity_minimum_is_exclusive():
+    """`exclusiveMinimum: 0` means more than zero, not at least zero.
+
+    Flattened to an inclusive bound, a zero-capacity message is accepted and
+    divides to a null fill percentage, which the stateful operator then
+    compares against a threshold and dies on.
+    """
+    rules = {name: exclusive for name, _, _, exclusive in range_rules()}
+
+    assert rules["capacity"] is True
+    assert rules["current_fill_level"] is False
+
+
+def test_the_contract_names_the_fields_that_cannot_be_empty():
+    from schema import non_empty_fields
+
+    assert set(non_empty_fields()) == {"bin_id", "zone"}
+
+
+def test_the_dashboard_views_are_built_with_the_pipeline_thresholds():
+    """The views and the alert rules must not disagree about "critical".
+
+    Hardcoded in the SQL, the demo profile's one-minute offline threshold left
+    city_kpi calling a bin active for fourteen minutes after it was alerted
+    offline.
+    """
+    from config import get_settings
+    from sinks import schema_sql
+
+    settings = get_settings()
+    sql = schema_sql()
+
+    assert "{" not in sql, "a placeholder was left unfilled"
+    assert f"{settings.CRITICAL_FILL_PCT}" in sql
+    assert f"{settings.OFFLINE_AFTER_MINUTES} * INTERVAL '1 minute'" in sql
+    assert "SLA_BREACH%" in sql

--- a/services/stream-processor/tests/test_schema.py
+++ b/services/stream-processor/tests/test_schema.py
@@ -1,0 +1,70 @@
+"""Tests for the schema built from the shared telemetry contract.
+
+The failure these guard against is silent. Spark reads Kafka JSON against a
+fixed schema, so a field the schema does not know about is simply absent: every
+rule reading it sees null, stops matching, and nothing fails or logs. Building
+the schema from the contract is what makes that impossible without an explicit,
+reviewable change to the contract file.
+"""
+
+from pyspark.sql.types import DoubleType, StringType
+
+from schema import (
+    EVENT_TIME_FIELD,
+    load_contract,
+    range_rules,
+    required_fields,
+    telemetry_schema,
+)
+
+
+def test_schema_covers_every_contracted_field():
+    """No contracted field is missing from the schema Spark reads with."""
+    assert set(telemetry_schema().fieldNames()) == set(load_contract()["properties"])
+
+
+def test_schema_types_follow_the_contract():
+    """Numbers are read as doubles and text as strings."""
+    fields = {field.name: field.dataType for field in telemetry_schema().fields}
+
+    assert fields["bin_id"] == StringType()
+    assert fields["zone"] == StringType()
+    assert fields[EVENT_TIME_FIELD] == StringType()
+    assert fields["capacity"] == DoubleType()
+    assert fields["current_fill_level"] == DoubleType()
+    assert fields["temperature"] == DoubleType()
+
+
+def test_every_field_is_nullable():
+    """A missing field must reach validation, not fail to parse.
+
+    Failing to parse discards the message with no explanation; reaching
+    validation dead-letters it with a reason someone can act on.
+    """
+    assert all(field.nullable for field in telemetry_schema().fields)
+
+
+def test_range_rules_cover_the_fields_with_bounds():
+    """The bounds used for validation come from the contract."""
+    rules = dict((name, (low, high)) for name, low, high in range_rules())
+
+    assert rules["battery_level"] == (0, 100)
+    assert rules["latitude"] == (-90, 90)
+    assert rules["temperature"][1] == 120
+
+
+def test_temperature_range_admits_a_fire_risk_reading():
+    """Validation must not reject the readings fire detection exists to catch.
+
+    An ambient-only range would dead-letter every bin above 70 C, which is
+    precisely the condition the fire rule looks for - and the rule would then
+    never fire, with the readings discarded as impossible upstream.
+    """
+    rules = dict((name, (low, high)) for name, low, high in range_rules())
+
+    assert rules["temperature"][1] > 70
+
+
+def test_required_fields_match_the_contract():
+    """Every property is required; the contract does not carry optional fields."""
+    assert set(required_fields()) == set(load_contract()["properties"])

--- a/services/stream-processor/tests/test_schema.py
+++ b/services/stream-processor/tests/test_schema.py
@@ -68,3 +68,17 @@ def test_temperature_range_admits_a_fire_risk_reading():
 def test_required_fields_match_the_contract():
     """Every property is required; the contract does not carry optional fields."""
     assert set(required_fields()) == set(load_contract()["properties"])
+
+
+def test_the_batch_job_does_not_take_the_streaming_ui_port():
+    """The two applications run together and need separate UI ports.
+
+    Sharing one means the batch job is pushed onto whatever Spark finds free,
+    so the address changes run to run and the log carries a warning that reads
+    like a fault.
+    """
+    from config import get_settings
+
+    settings = get_settings()
+
+    assert settings.SPARK_UI_PORT != settings.SPARK_BATCH_UI_PORT

--- a/services/stream-processor/tests/test_shutdown.py
+++ b/services/stream-processor/tests/test_shutdown.py
@@ -1,0 +1,113 @@
+"""Tests for stopping the streaming application cleanly.
+
+Before this, SIGTERM was ignored: the main thread sat inside an unbounded
+`awaitAnyTermination`, Python could not run the handler until that call
+returned, and Docker sent SIGKILL after the grace period. Every stop reported
+as exit 137. Nothing was lost - checkpoints and idempotent writes cover a kill -
+but a crash exit code on an ordinary stop is the wrong signal to leave behind.
+"""
+
+import threading
+
+import pytest
+
+from main import run
+
+
+class FakeQuery:
+    def __init__(self, name):
+        self.name = name
+        self.isActive = True
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+        self.isActive = False
+
+
+class FakeStreams:
+    def __init__(self, terminates_after=None, raises=None):
+        self.calls = 0
+        self._terminates_after = terminates_after
+        self._raises = raises
+
+    def awaitAnyTermination(self, timeout=None):
+        self.calls += 1
+        if self._raises is not None:
+            raise self._raises
+        return self._terminates_after is not None and self.calls >= self._terminates_after
+
+
+class FakeSession:
+    def __init__(self, streams):
+        self.streams = streams
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_a_stop_request_stops_every_query_and_the_session():
+    queries = [FakeQuery("bin_events"), FakeQuery("bin_state")]
+    session = FakeSession(FakeStreams())
+    stop_requested = threading.Event()
+    stop_requested.set()
+
+    run(session, queries, stop_requested)
+
+    assert all(query.stopped for query in queries)
+    assert session.stopped
+
+
+def test_the_wait_is_bounded_so_a_signal_is_noticed():
+    """An unbounded wait is what swallowed SIGTERM."""
+    queries = [FakeQuery("bin_state")]
+    streams = FakeStreams()
+    session = FakeSession(streams)
+    stop_requested = threading.Event()
+
+    # Set the flag from the fake's third poll, as a signal handler would.
+    original = streams.awaitAnyTermination
+
+    def poll(timeout=None):
+        if streams.calls >= 2:
+            stop_requested.set()
+        return original(timeout=timeout)
+
+    streams.awaitAnyTermination = poll
+
+    run(session, queries, stop_requested)
+
+    assert streams.calls == 3
+    assert session.stopped
+
+
+def test_a_query_ending_on_its_own_also_shuts_down():
+    queries = [FakeQuery("bin_state")]
+    session = FakeSession(FakeStreams(terminates_after=1))
+
+    run(session, queries, threading.Event())
+
+    assert queries[0].stopped
+    assert session.stopped
+
+
+def test_a_failing_query_still_surfaces_its_error():
+    """The failure must not be swallowed by the shutdown path."""
+    session = FakeSession(FakeStreams(raises=RuntimeError("query failed")))
+
+    with pytest.raises(RuntimeError, match="query failed"):
+        run(session, [FakeQuery("bin_state")], threading.Event())
+
+
+def test_an_already_stopped_query_is_not_stopped_twice():
+    query = FakeQuery("bin_state")
+    query.isActive = False
+    session = FakeSession(FakeStreams())
+    stop_requested = threading.Event()
+    stop_requested.set()
+
+    run(session, [query], stop_requested)
+
+    assert not query.stopped
+    assert session.stopped

--- a/services/stream-processor/tests/test_streaming.py
+++ b/services/stream-processor/tests/test_streaming.py
@@ -14,7 +14,8 @@ import json
 import pytest
 from pyspark.sql.functions import col, lit
 
-from pipeline.clean import clean_events
+from pipeline.bin_state import evaluate
+from pipeline.clean import clean_events, dead_letters
 from pipeline.zone_metrics import aggregate
 
 
@@ -164,7 +165,7 @@ def test_the_stateful_operator_runs_under_spark(run_stream, telemetry):
     operator yields match the declared output schema, and that grouping by bin
     reaches the function at all.
     """
-    from pipeline.bin_state import RECORD_ALERT, RECORD_STATE, evaluate
+    from pipeline.bin_state import RECORD_ALERT, RECORD_STATE
 
     def transform(raw):
         return evaluate(clean_events(raw))
@@ -223,3 +224,40 @@ def test_zone_windows_aggregate_readings(run_stream, telemetry):
     # One bin in three is at 90%, which is over the critical threshold
     assert first["critical_readings"] > 0
     assert first["max_fill_pct"] == pytest.approx(90.0)
+
+
+def test_a_zero_capacity_message_is_dead_lettered_not_processed(
+    run_stream, telemetry
+):
+    """The end-to-end version of the crash this fixed.
+
+    A zero capacity divided to a null fill percentage, which the stateful
+    operator compared against a threshold, which raised in the Python worker
+    and terminated the streaming application. The message must be dead-lettered
+    before it reaches any of that, and the healthy bin beside it must survive.
+    """
+    letters = run_stream(
+        dead_letters,
+        [telemetry(bin_id="BIN-OK"), telemetry(bin_id="BIN-ZERO", capacity=0.0)],
+        "dlq_zero_capacity",
+    )
+
+    assert len(letters) == 1
+    assert letters[0]["key"] == "BIN-ZERO"
+    assert "capacity_out_of_range" in json.loads(letters[0]["value"])["reason"]
+
+
+def test_the_operator_survives_the_message_that_used_to_kill_it(
+    run_stream, telemetry
+):
+    """The stateful query runs to completion with the bad message in the batch."""
+    rows = run_stream(
+        lambda raw: evaluate(clean_events(raw)),
+        [
+            telemetry(bin_id="BIN-ZERO", capacity=0.0),
+            telemetry(bin_id="BIN-OK", current_fill_level=90.0),
+        ],
+        "state_zero_capacity",
+    )
+
+    assert {row["bin_id"] for row in rows} == {"BIN-OK"}

--- a/services/stream-processor/tests/test_streaming.py
+++ b/services/stream-processor/tests/test_streaming.py
@@ -133,6 +133,44 @@ def test_invalid_readings_never_reach_the_clean_stream(run_stream, telemetry):
     assert [row["bin_id"] for row in rows] == ["BIN-OK"]
 
 
+def test_the_stateful_operator_runs_under_spark(run_stream, telemetry):
+    """The per-bin rules are exercised through the real Spark operator.
+
+    The rules themselves are tested directly and far more thoroughly without a
+    cluster. What this covers is the wiring those tests cannot: that the state
+    schema round-trips through Spark's state store, that the pandas frames the
+    operator yields match the declared output schema, and that grouping by bin
+    reaches the function at all.
+    """
+    from pipeline.bin_state import RECORD_ALERT, RECORD_STATE, evaluate
+
+    def transform(raw):
+        return evaluate(clean_events(raw))
+
+    messages = [
+        telemetry(
+            bin_id="BIN-FILLING",
+            timestamp=f"2026-08-22T10:{index:02d}:00+00:00",
+            # Crosses the critical threshold partway through
+            current_fill_level=40.0 + index * 5,
+        )
+        for index in range(12)
+    ]
+
+    rows = run_stream(transform, messages, "stateful")
+
+    by_type = {row["record_type"] for row in rows}
+    assert RECORD_STATE in by_type
+    assert RECORD_ALERT in by_type
+
+    alerts = {row["alert_type"] for row in rows if row["record_type"] == RECORD_ALERT}
+    assert "CRITICAL_FILL" in alerts
+
+    state_rows = [row for row in rows if row["record_type"] == RECORD_STATE]
+    assert state_rows[-1]["bin_id"] == "BIN-FILLING"
+    assert state_rows[-1]["last_seen"] is not None
+
+
 def test_zone_windows_aggregate_readings(run_stream, telemetry):
     """A five-minute window carries the counts and averages rollups need.
 

--- a/services/stream-processor/tests/test_streaming.py
+++ b/services/stream-processor/tests/test_streaming.py
@@ -119,18 +119,40 @@ def test_fill_pct_is_attached_to_the_clean_stream(run_stream, telemetry):
     assert rows[0]["fill_pct"] == pytest.approx(50.0)
 
 
-def test_invalid_readings_never_reach_the_clean_stream(run_stream, telemetry):
-    """Impossible values are filtered out before anything downstream sees them."""
+def test_unusable_messages_never_reach_the_clean_stream(run_stream, telemetry):
+    """A message with nothing salvageable is filtered before anything sees it."""
     rows = run_stream(
         clean_events,
         [
             telemetry(bin_id="BIN-OK"),
-            telemetry(bin_id="BIN-BAD", temperature=999.0),
+            telemetry(bin_id="BIN-BAD", current_fill_level=9999.0),
         ],
         "clean_filters",
     )
 
     assert [row["bin_id"] for row in rows] == ["BIN-OK"]
+
+
+def test_a_bin_with_one_broken_sensor_still_reaches_the_clean_stream(
+    run_stream, telemetry
+):
+    """It stays in the stream, with only the unusable reading nulled.
+
+    This is what keeps the bin in the state store, so it still goes on the
+    collection list and still arms an offline timeout. Discarding the whole
+    message made a bin that was publishing every few seconds invisible to
+    every downstream figure.
+    """
+    rows = run_stream(
+        clean_events,
+        [telemetry(bin_id="BIN-HOT-SENSOR", temperature=999.0, current_fill_level=88.0)],
+        "clean_repairs",
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["temperature"] is None
+    assert rows[0]["fill_pct"] == pytest.approx(88.0)
+    assert "temperature" in rows[0]["sensor_faults"]
 
 
 def test_the_stateful_operator_runs_under_spark(run_stream, telemetry):

--- a/services/stream-processor/tests/test_streaming.py
+++ b/services/stream-processor/tests/test_streaming.py
@@ -1,0 +1,165 @@
+"""Tests that need a real stream rather than a batch DataFrame.
+
+Almost everything in the pipeline is a plain DataFrame transformation and is
+tested on batch data, which is faster and clearer. Two things are not:
+deduplication needs a watermark, which only exists on a streaming DataFrame, and
+the windowed aggregate only emits once a watermark has advanced past a window.
+
+These run against a file source rather than Kafka so the tests need no broker.
+The transformation under test is the same code the Kafka source drives.
+"""
+
+import json
+
+import pytest
+from pyspark.sql.functions import col, lit
+
+from pipeline.clean import clean_events
+from pipeline.zone_metrics import aggregate
+
+
+def as_kafka_shape(stream):
+    """Give a text stream the column shape the Kafka source produces."""
+    return stream.select(
+        col("value").cast("binary").alias("value"),
+        lit("smartbin-telemetry-v1").alias("topic"),
+        lit(0).alias("partition"),
+        lit(0).cast("long").alias("offset"),
+    )
+
+
+@pytest.fixture
+def run_stream(spark, tmp_path):
+    """Write messages to a file source, run a transformation, return the rows.
+
+    `processAllAvailable` blocks until every file has been consumed, so the
+    assertions see a finished result rather than racing the query.
+    """
+
+    def run(transform, messages, table):
+        source = tmp_path / "input"
+        source.mkdir()
+        (source / "events.json").write_text(
+            "\n".join(json.dumps(message) for message in messages)
+        )
+
+        stream = spark.readStream.format("text").load(str(source))
+        query = (
+            transform(as_kafka_shape(stream))
+            .writeStream.format("memory")
+            .queryName(table)
+            .outputMode("append")
+            .option("checkpointLocation", str(tmp_path / f"checkpoint-{table}"))
+            .start()
+        )
+        try:
+            query.processAllAvailable()
+        finally:
+            query.stop()
+
+        return spark.sql(f"SELECT * FROM {table}").collect()
+
+    return run
+
+
+def test_duplicate_events_are_removed(run_stream, telemetry):
+    """The same reading sent twice is counted once.
+
+    Deduplication keys on the bin and the event time, which is why a re-sent
+    duplicate has to carry its original timestamp. This is the positive case for
+    that: two byte-identical messages collapse to one.
+    """
+    event = telemetry()
+
+    rows = run_stream(clean_events, [event, event, event], "dedupe_same")
+
+    assert len(rows) == 1
+
+
+def test_distinct_readings_are_all_kept(run_stream, telemetry):
+    """Deduplication does not swallow genuine consecutive readings.
+
+    The counterpart to the test above - a rule that dropped everything would
+    pass that one and be badly wrong.
+    """
+    rows = run_stream(
+        clean_events,
+        [
+            telemetry(timestamp="2026-08-22T10:00:00+00:00"),
+            telemetry(timestamp="2026-08-22T10:00:05+00:00"),
+            telemetry(timestamp="2026-08-22T10:00:10+00:00"),
+        ],
+        "dedupe_distinct",
+    )
+
+    assert len(rows) == 3
+
+
+def test_the_same_instant_from_different_bins_is_not_a_duplicate(
+    run_stream, telemetry
+):
+    """Two bins reporting at the same moment are two readings, not one."""
+    rows = run_stream(
+        clean_events,
+        [telemetry(bin_id="BIN-A"), telemetry(bin_id="BIN-B")],
+        "dedupe_bins",
+    )
+
+    assert len(rows) == 2
+
+
+def test_fill_pct_is_attached_to_the_clean_stream(run_stream, telemetry):
+    """The clean stream carries the percentage every downstream rule compares."""
+    rows = run_stream(
+        clean_events,
+        [telemetry(capacity=240.0, current_fill_level=120.0)],
+        "clean_fill_pct",
+    )
+
+    assert rows[0]["fill_pct"] == pytest.approx(50.0)
+
+
+def test_invalid_readings_never_reach_the_clean_stream(run_stream, telemetry):
+    """Impossible values are filtered out before anything downstream sees them."""
+    rows = run_stream(
+        clean_events,
+        [
+            telemetry(bin_id="BIN-OK"),
+            telemetry(bin_id="BIN-BAD", temperature=999.0),
+        ],
+        "clean_filters",
+    )
+
+    assert [row["bin_id"] for row in rows] == ["BIN-OK"]
+
+
+def test_zone_windows_aggregate_readings(run_stream, telemetry):
+    """A five-minute window carries the counts and averages rollups need.
+
+    Append mode only emits a window once the watermark has moved past it, so the
+    input spans well over the window and watermark to force one closed.
+    """
+
+    def transform(raw):
+        return aggregate(clean_events(raw))
+
+    messages = [
+        telemetry(
+            bin_id=f"BIN-{index % 3}",
+            timestamp=f"2026-08-22T10:{index:02d}:00+00:00",
+            current_fill_level=90.0 if index % 3 == 0 else 20.0,
+        )
+        for index in range(45)
+    ]
+
+    rows = run_stream(transform, messages, "zone_windows")
+
+    assert rows, "no window was emitted"
+
+    first = rows[0]
+    assert first["zone"] == "CENTRAL"
+    assert first["bins_reporting"] == 3
+    assert first["reading_count"] > 0
+    # One bin in three is at 90%, which is over the critical threshold
+    assert first["critical_readings"] > 0
+    assert first["max_fill_pct"] == pytest.approx(90.0)


### PR DESCRIPTION
## Summary

Stacked on #49. Adds the Spark processing layer as a new `services/stream-processor/`, plus the simulator changes it depends on.

One PySpark application reads `smartbin-telemetry-v1` and runs four streaming queries and one nightly batch job. All fifteen client problem statements are answered.

| Query | Writes | Answers |
|---|---|---|
| `bin_events` | Parquet, by date | The history behind trends, and anything not yet asked |
| `dead_letters` | `smartbin-telemetry-dlq` | Messages that could not be parsed or believed |
| `zone_metrics` | `zone_metrics_5m` | Per-zone rollups at every grain, by SQL |
| `bin_state` | `bin_alerts`, `bin_state_latest` | Twelve alert types from one per-bin state read |
| `batch/rollups.py` | `zone_hourly_profile`, `zone_daily_trend` | Peak hours, long-range trends |

The batch job runs in a `rollups` container on `ROLLUP_INTERVAL_SECONDS` (default fifteen minutes), so the analytical tables fill on their own.

Dashboard KPIs are the `city_kpi` and `zone_leaderboard` views — no Spark job of their own.

## Departures from the design doc

- **No JDBC join in Query 1.** #49 puts `zone` and `capacity` on every event, so the design's `broadcast(bins_static)` lookup is unnecessary. Removes the database from the hot path and the case where a bin registered after startup is enriched with nulls.
- **`temperature`, not `temperature_c`** — matching what #49 already ships.
- **All Postgres writes are idempotent.** The doc says "append". A micro-batch is retried after a failed write, so appending double-counts on every retry. Every table has a key a retry collides with.
- **Twelve alert types, not ten.** `SENSOR_FAULT` is new — see validation below. `SLA_BREACH` is two types, because both clocks can come due on the same reading and `bin_alerts` is keyed on `(bin_id, alert_type, fired_at)` — under one shared type the second row was silently dropped on insert.
- **Ten fault modes, not six.** Added `UNCOLLECTED`: every healthy bin is emptied well inside the SLA, so without a bin the truck never comes for, `SLA_BREACH` could never fire.

## Validation is per field, not per message

A reading with one impossible value used to be discarded whole. That lost the bin: a `SPIKE` sensor reporting 150 °C took its fill level, position and battery down with it, and `bin_state_latest` showed 196 of 200 bins with no indication that four were missing rather than idle.

Now only the fields needed to track the bin at all — `bin_id`, `zone`, `capacity`, `current_fill_level`, `event_time` — are fatal. A bad `temperature`, `battery_level`, `latitude` or `longitude` is nulled, the reading proceeds, and a `SENSOR_FAULT` alert names the field. The bin stays visible and the fault is stated rather than inferred from an absence. `city_kpi` carries `faulty_sensor_bins` for the same reason.

## Simulator changes this depends on

- **Fault injection.** Six of the detectors had no condition to detect. Modes are assigned by cycling, not per-bin coin flips, so a small fleet can't end up with no hot bin and therefore no fire alert anywhere in the run.
- **The temperature clamp is gone.** It capped at 35 °C while the fire rule looks for 70 °C, so `FIRE_RISK` could never fire. A hot bin now scales temperature with fill level, which satisfies both halves of the rule together and needs no retuning when capacity or fill rate change.
- **Realistic pacing.** Fill was 0.5–5.0 per 5s — a full bin in three minutes against a two-hour SLA. Also bins were emptied at *any* fill level, including below the critical threshold, so a bin never registered as critical and the drop wasn't recognisable as a collection. Collection now happens above the critical level, and the rate is a percentage of capacity so every bin size crosses percentage thresholds at the same pace.
- **`contracts/telemetry-v1.json`** — one payload contract both services assert against. A renamed field otherwise reads as nulls downstream with nothing failing.

## Startup and operability

Running this stack surfaced three ways it failed quietly. All are fixed here.

- **`alembic upgrade head` printed nothing at all** — success and no-op looked identical. Alembic logs through `logging.config.fileConfig`, which needs *both* the logger sections in `alembic.ini` and the `fileConfig(...)` call in `alembic/env.py`; only one was present. `disable_existing_loggers=False`, because `env.py` also runs inside the test suite. Each applied revision is now named.
- **Starting against an unmigrated database** produced a thirty-line SQLAlchemy traceback with the useful line at the bottom, *and* leaked the Kafka producer — cleanup sat after `await stop_event.wait()`, so a startup failure skipped it entirely and the process died complaining about the leak instead of the cause. Now: a `SchemaNotReadyError` naming the two commands to run, cleanup in `finally` with each step separately guarded, exit 1. A migrated-but-unseeded database warns with the seed command rather than reporting `Started 0 simulator(s)`. Shutdown no longer emits ~200 cancellation warnings for what is the normal stop path.
- **The Spark UI was unreachable** — compose published no ports. Now 4040 (streaming) and 4041 (batch), explicitly assigned with `spark.ui.portMaxRetries=0` so the address never silently moves when a port is taken.

README gained an "Order matters" table mapping each bad startup state to the exact line it produces, and the note that **a healthy simulator logs nothing after startup** — per-tick telemetry is DEBUG, so an idle-looking `docker logs -f` is the working case.

## Infrastructure

- Topics created explicitly: 12 partitions, and the DLQ. Auto-creation gave one partition, pinning the whole stream to one task.
- `pr-pytest.yml` is now a matrix over services — it was hardcoded to `data-simulator`, so a new service's tests would never have run. Each service carries its own Python version.

> **Python 3.11 for the stream processor.** PySpark 3.5 supports up to 3.11; on 3.12 its pandas operators fail at run time importing `distutils`. Query 2 would have been dead on arrival.

## Review findings

An external review raised eleven findings. All eleven were real and all eleven are fixed; two more came out of running the result.

| Finding | Fix |
|---|---|
| Zero `capacity` accepted | Worse than reported — an unconditional crash. It divides to a null `fill_pct`, and every fill rule compares that against a threshold, raising in the Python worker and terminating the application. `exclusiveMinimum` is now carried through validation instead of flattened away. |
| Nothing scheduled the "nightly" job | A `rollups` container on a timer. Fifteen minutes, not a day — a day means the tables sit empty through every demo. |
| `startingOffsets: latest` raced the simulator | `earliest`. On a fresh checkpoint the old default skipped everything published while Spark built four queries — fatal for a bin that falls silent by design, which then never enters the state store and never arms an offline timeout. |
| A dip below the threshold reset the SLA clock | Fire-once flags clear on a collection and nothing else. A bin wobbling around 80% re-alerted on every crossing and restarted a two-hour clock each time. |
| Healthy full bins reported `SENSOR_STUCK` | Fill is clamped at capacity, so every bin awaiting a truck repeats 100%. Those readings no longer count. |
| Rollup failures exited zero | It asks the filesystem whether the path exists — the one condition that is genuinely fine — and lets corruption, permissions and schema errors propagate. |
| Two `SLA_BREACH` rows collided | `SLA_BREACH_CRITICAL` and `SLA_BREACH_OVERFLOW`. |
| A second failing sensor raised nothing | State remembers *which* sensors were reported, not merely that one was. |
| Views hardcoded 15/80/95/20 | `apply_schema()` fills the thresholds in from the same settings the rules read. |
| Empty `bin_id` / `zone` accepted | The contract's `minLength` is enforced; empty is not missing, and it becomes a shared state key. |
| `updated_at` frozen at insert | Written explicitly in the upsert. |

Two more, found by running it rather than by review:

- **The `SENSOR_STUCK` fix broke `SENSOR_STUCK`.** Excluding both rails looked symmetric and was not. Bins are seeded empty and `FROZEN` freezes bin state, so every frozen bin in the fleet sat at exactly 0% — the detector was suppressed for precisely the bins it exists to catch. Fill is *clamped* at capacity, so 100% repeating says nothing about the sensor; nothing clamps a bin at empty, so 0% repeating means it stopped. Excluded at 100% only.
- **Every stop was a SIGKILL.** The main thread sat in an unbounded `awaitAnyTermination`, and Python runs signal handlers between bytecodes — so SIGTERM went unnoticed until Docker gave up, and each stop reported exit 137. Nothing was lost, but a crash exit code on an ordinary stop hides a real crash. Bounded poll, queries stopped by name, `stop_grace_period: 60s`.

## Verification

Both suites green: **98 passed, 1 skipped** (data-simulator), **135 passed** (stream-processor). `ruff check .` clean.

Run end to end from a wiped volume — Postgres, Kafka with 12 partitions, 200 seeded bins, 30 with injected faults:

- **All twelve alert types fired**, including `SENSOR_STUCK`, `FIRE_RISK`, `OFFLINE` and both SLA breaches
- `bin_state_latest` — `total_bins=200`, `faulty_sensor_bins=4`, `zones_covered=5`
- `zone_metrics_5m` — 15 windows across all five zones
- DLQ — 120 messages, each with reason, provenance and the original payload intact
- Parquet — date-partitioned; the `rollups` container wrote both tables **on its own timer**, no manual step
- `city_kpi` — every figure populated; Spark UI serving all four queries
- **Zero error lines in either service**; both stop with exit 0

A useful cross-check: collections counted by the batch window function and `COLLECTED` alerts counted by the streaming rule agree to within the events still in flight — two independent paths over the same data reaching the same number.

Several bugs were found by running it rather than by the tests, and are fixed here: contract path resolution broke inside the image; a `SILENT` bin never entered the state store, so no offline timeout was ever armed for it; 80% fill was unreachable because collection triggered below the critical threshold; and large bins never crossed percentage thresholds while the fill rate was absolute.

## Notes for review

- A PR targeting #49's branch triggers neither `pr-controller.yml` nor `pr-pytest.yml` — both are `branches: [develop]`. CI starts once #49 merges and this retargets.
- `services/stream-processor/sql/schema.sql` is the storage contract, and is what should be pasted into the empty `docs/features/binvault/02-BinVaultData-modeling.md`.
- Zone-vs-ward stays deferred; code is on `zone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUnC1hJvY9vy6iy7LHtPyq
